### PR TITLE
REST and WebSocket support for Binance Futures

### DIFF
--- a/fixture/vcr_cassettes/futures/create_listen_key_ok.json
+++ b/fixture/vcr_cassettes/futures/create_listen_key_ok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "recvWindow=1000&timestamp=1568883486915&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/listenKey"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"listenKey\":\"SHKiq1MSr119hfs4ZB6EZWkdikAPq8RGVuQGdGMnvvUUmaeZygVcoO1CchfzXeCd\"}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "80",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 08:58:07 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "1ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 abaf9410e0cb5238ad0ea84e120ca7c0.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "ATxzJhdZNEaa2B2YvpqKNuYfrRpjMqV_P72j0TkbITAQOJ9OI4cSMw=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_account_ok.json
+++ b/fixture/vcr_cassettes/futures/get_account_ok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/account?recvWindow=5000&timestamp=1568882788189&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"feeTier\":0,\"canTrade\":true,\"canDeposit\":true,\"canWithdraw\":true,\"updateTime\":0,\"totalInitialMargin\":\"0.00000000\",\"totalMaintMargin\":\"0.00000000\",\"totalWalletBalance\":\"10.18000000\",\"totalUnrealizedProfit\":\"0.00000000\",\"totalMarginBalance\":\"10.18000000\",\"assets\":[{\"asset\":\"USDT\",\"walletBalance\":\"10.18000000\",\"unrealizedProfit\":\"0.00000000\",\"marginBalance\":\"10.18000000\",\"maintMargin\":\"0.00000000\",\"initialMargin\":\"0.00000000\"}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "430",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 08:46:28 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "8ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 c379fc647ec433c74b9813bff8a9cf0f.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "0WIhLOJMm-PJkF8mniggHEpMc8wVjle3iBzI3D_bdHVKlMs-glG4mQ=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_depth_ok.json
+++ b/fixture/vcr_cassettes/futures/get_depth_ok.json
@@ -1,0 +1,35 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/depth?symbol=BTCUSDT&limit=5"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"lastUpdateId\":36154698,\"bids\":[[\"9875.74\",\"1.849\"],[\"9875.59\",\"2.752\"],[\"9875.16\",\"2.588\"],[\"9874.67\",\"1.547\"],[\"9873.80\",\"3.647\"]],\"asks\":[[\"9876.71\",\"2.569\"],[\"9877.08\",\"1.745\"],[\"9877.48\",\"1.743\"],[\"9878.15\",\"1.580\"],[\"9878.36\",\"3.091\"]]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "243",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 07:55:24 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "0ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 2276141e64b3e76ad879a6638f87396c.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "Mqeq_ekILftDJu2pPPON73tO4WeZMUwTPcw3UsfxeUNJl8P4owj_JQ=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_exchange_info_ok.json
+++ b/fixture/vcr_cassettes/futures/get_exchange_info_ok.json
@@ -1,0 +1,35 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/exchangeInfo"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"timezone\":\"UTC\",\"serverTime\":1568879257222,\"rateLimits\":[{\"rateLimitType\":\"REQUEST_WEIGHT\",\"interval\":\"MINUTE\",\"intervalNum\":1,\"limit\":1200},{\"rateLimitType\":\"ORDERS\",\"interval\":\"MINUTE\",\"intervalNum\":1,\"limit\":600}],\"exchangeFilters\":[],\"symbols\":[{\"symbol\":\"BTCUSDT\",\"status\":\"TRADING\",\"maintMarginPercent\":\"2.5000\",\"requiredMarginPercent\":\"5.0000\",\"baseAsset\":\"BTC\",\"quoteAsset\":\"USDT\",\"pricePrecision\":2,\"quantityPrecision\":3,\"baseAssetPrecision\":8,\"quotePrecision\":8,\"filters\":[{\"minPrice\":\"0.01\",\"maxPrice\":\"100000\",\"filterType\":\"PRICE_FILTER\",\"tickSize\":\"0.01\"},{\"stepSize\":\"0.001\",\"filterType\":\"LOT_SIZE\",\"maxQty\":\"1000\",\"minQty\":\"0.001\"},{\"stepSize\":\"0.001\",\"filterType\":\"MARKET_LOT_SIZE\",\"maxQty\":\"1000\",\"minQty\":\"0.001\"},{\"limit\":0,\"filterType\":\"MAX_NUM_ORDERS\"},{\"multiplierDown\":\"0.8500\",\"multiplierUp\":\"1.1500\",\"multiplierDecimal\":\"4\",\"filterType\":\"PERCENT_PRICE\"}],\"orderTypes\":[\"LIMIT\",\"MARKET\",\"STOP\"],\"timeInForce\":[\"GTC\",\"IOC\",\"FOK\",\"GTX\"]}]}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "963",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 07:47:37 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "0ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 0e4baa40f8860e2e0eea54b2a4c33ba5.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "6qBnecgZ0Fy24cPTxeK2Z_su5swpnwXNyTYMoB0ovN-BIOCFdVmcdw=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_server_time_ok.json
+++ b/fixture/vcr_cassettes/futures/get_server_time_ok.json
@@ -1,0 +1,34 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/time"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"serverTime\":1568879218176}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "28",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 07:46:58 GMT",
+        "Server": "Tengine",
+        "x-response-time": "0ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 37a7b82c9bd3774d003812bdfacee460.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "T-BkzZUamsGJavqYGWuPCBabkqukbedY5oMmqn_l8x1T0HJMU23ykw=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/keep_alive_listen_key_ok.json
+++ b/fixture/vcr_cassettes/futures/keep_alive_listen_key_ok.json
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "body": "recvWindow=1000&timestamp=1568883876220&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "put",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/listenKey"
+    },
+    "response": {
+      "binary": false,
+      "body": "",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "0",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 09:04:36 GMT",
+        "Server": "Tengine",
+        "x-response-time": "0ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 62984a52337afed4f5d9b3351d33e75c.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "v551i2QhW9kefM5jU5_INBe8xDh_EpKLEVwaNHmDR2sjHkdGQJoutA=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/ping_ok.json
+++ b/fixture/vcr_cassettes/futures/ping_ok.json
@@ -1,0 +1,34 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": [],
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/ping"
+    },
+    "response": {
+      "binary": false,
+      "body": "{}",
+      "headers": {
+        "Content-Type": "text/plain",
+        "Content-Length": "2",
+        "Connection": "keep-alive",
+        "Date": "Thu, 19 Sep 2019 08:49:48 GMT",
+        "Server": "Tengine",
+        "x-response-time": "0ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 8730481efae5d62c03ca8bf771c54e2f.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "XBMvdAjI_dqEWcX2Hz0cqes-Ypeo8CF7yVlAH6tL8OrC-zH2n3ZqZQ=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/binance/futures.ex
+++ b/lib/binance/futures.ex
@@ -141,7 +141,7 @@ defmodule Binance.Futures do
 
     case HTTPClient.get_binance("/fapi/v1/account", %{}, secret_key, api_key) do
       {:ok, data} ->
-        {:ok, Binance.Account.new(data)}
+        {:ok, Binance.Futures.Account.new(data)}
 
       error ->
         error

--- a/lib/binance/futures.ex
+++ b/lib/binance/futures.ex
@@ -1,0 +1,150 @@
+defmodule Binance.Futures do
+  alias Binance.Futures.Rest.HTTPClient
+
+  # Server
+
+  @doc """
+  Pings Binance API. Returns `{:ok, %{}}` if successful, `{:error, reason}` otherwise
+  """
+  def ping() do
+    HTTPClient.get_binance("/fapi/v1/ping")
+  end
+
+  @doc """
+  Get binance server time in unix epoch.
+
+  Returns `{:ok, time}` if successful, `{:error, reason}` otherwise
+
+  ## Example
+  ```
+  {:ok, 1515390701097}
+  ```
+
+  """
+  def get_server_time() do
+    case HTTPClient.get_binance("/fapi/v1/time") do
+      {:ok, %{"serverTime" => time}} -> {:ok, time}
+      err -> err
+    end
+  end
+
+  def get_exchange_info() do
+    case HTTPClient.get_binance("/fapi/v1/exchangeInfo") do
+      {:ok, data} -> {:ok, Binance.ExchangeInfo.new(data)}
+      err -> err
+    end
+  end
+
+  def create_listen_key(
+        receiving_window \\ 1000,
+        timestamp \\ nil
+      ) do
+    timestamp =
+      case timestamp do
+        # timestamp needs to be in milliseconds
+        nil ->
+          :os.system_time(:millisecond)
+
+        t ->
+          t
+      end
+
+    arguments = %{
+      timestamp: timestamp,
+      recvWindow: receiving_window
+    }
+
+    case HTTPClient.post_binance("/fapi/v1/listenKey", arguments) do
+      {:ok, %{"code" => code, "msg" => msg}} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}}
+
+      data ->
+        data
+    end
+  end
+
+  def keep_alive_listen_key(receiving_window \\ 1000, timestamp \\ nil) do
+    timestamp =
+      case timestamp do
+        # timestamp needs to be in milliseconds
+        nil ->
+          :os.system_time(:millisecond)
+
+        t ->
+          t
+      end
+
+    arguments = %{
+      timestamp: timestamp,
+      recvWindow: receiving_window
+    }
+
+    case HTTPClient.put_binance("/fapi/v1/listenKey", arguments) do
+      {:ok, %{"code" => code, "msg" => msg}} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}}
+
+      data ->
+        data
+    end
+  end
+
+  @doc """
+  Retrieves the bids & asks of the order book up to the depth for the given symbol
+
+  Returns `{:ok, %{bids: [...], asks: [...], lastUpdateId: 12345}}` or `{:error, reason}`
+
+  ## Example
+  ```
+  {:ok,
+    %Binance.OrderBook{
+      asks: [
+        ["8400.00000000", "2.04078100", []],
+        ["8405.35000000", "0.50354700", []],
+        ["8406.00000000", "0.32769800", []],
+        ["8406.33000000", "0.00239000", []],
+        ["8406.51000000", "0.03241000", []]
+      ],
+      bids: [
+        ["8393.00000000", "0.20453200", []],
+        ["8392.57000000", "0.02639000", []],
+        ["8392.00000000", "1.40893300", []],
+        ["8390.09000000", "0.07047100", []],
+        ["8388.72000000", "0.04577400", []]
+      ],
+      last_update_id: 113634395
+    }
+  }
+  ```
+  """
+  def get_depth(symbol, limit) do
+    case HTTPClient.get_binance("/fapi/v1/depth?symbol=#{symbol}&limit=#{limit}") do
+      {:ok, data} -> {:ok, Binance.OrderBook.new(data)}
+      err -> err
+    end
+  end
+
+  # Account
+
+  @doc """
+  Fetches user account from binance
+
+  Returns `{:ok, %Binance.Account{}}` or `{:error, reason}`.
+
+  In the case of a error on binance, for example with invalid parameters, `{:error, {:binance_error, %{code: code, msg: msg}}}` will be returned.
+
+  Please read https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/
+  """
+
+  def get_account() do
+    api_key = Application.get_env(:binance, :api_key)
+    secret_key = Application.get_env(:binance, :secret_key)
+
+    case HTTPClient.get_binance("/fapi/v1/account", %{}, secret_key, api_key) do
+      {:ok, data} ->
+        {:ok, Binance.Account.new(data)}
+
+      error ->
+        error
+    end
+  end
+end

--- a/lib/binance/futures/account.ex
+++ b/lib/binance/futures/account.ex
@@ -1,0 +1,37 @@
+defmodule Binance.Futures.Account do
+  @moduledoc """
+  Struct for representing a result row as returned by /api/v3/account
+
+  ```
+  defstruct [
+    :fee_tier,
+    :total_initial_margin,
+    :total_maint_margin,
+    :total_margin_balance,
+    :total_unrealized_profit,
+    :total_wallet_balance,
+    :can_trade,
+    :can_withdraw,
+    :can_deposit,
+    :assets,
+    :update_time,
+  ]
+  ```
+  """
+
+  defstruct [
+    :fee_tier,
+    :total_initial_margin,
+    :total_maint_margin,
+    :total_margin_balance,
+    :total_unrealized_profit,
+    :total_wallet_balance,
+    :can_trade,
+    :can_withdraw,
+    :can_deposit,
+    :assets,
+    :update_time
+  ]
+
+  use ExConstructor
+end

--- a/lib/binance/futures/rest/http_client.ex
+++ b/lib/binance/futures/rest/http_client.ex
@@ -1,0 +1,150 @@
+defmodule Binance.Futures.Rest.HTTPClient do
+  @endpoint "https://fapi.binance.com"
+
+  def get_binance(url, headers \\ []) do
+    "#{@endpoint}#{url}"
+    |> HTTPoison.get(headers)
+    |> parse_response
+  end
+
+  def delete_binance(url, headers \\ []) do
+    "#{@endpoint}#{url}"
+    |> HTTPoison.delete(headers)
+    |> parse_response
+  end
+
+  def get_binance(url, params, secret_key, api_key) do
+    case prepare_request(url, params, secret_key, api_key) do
+      {:error, _} = error ->
+        error
+
+      {:ok, url, headers} ->
+        get_binance(url, headers)
+    end
+  end
+
+  def delete_binance(url, params, secret_key, api_key) do
+    case prepare_request(url, params, secret_key, api_key) do
+      {:error, _} = error ->
+        error
+
+      {:ok, url, headers} ->
+        delete_binance(url, headers)
+    end
+  end
+
+  defp prepare_request(url, params, secret_key, api_key) do
+    case validate_credentials(secret_key, api_key) do
+      {:error, _} = error ->
+        error
+
+      _ ->
+        headers = [{"X-MBX-APIKEY", api_key}]
+        receive_window = 5000
+        ts = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
+
+        params =
+          Map.merge(params, %{
+            timestamp: ts,
+            recvWindow: receive_window
+          })
+
+        argument_string = URI.encode_query(params)
+
+        signature =
+          :crypto.hmac(
+            :sha256,
+            secret_key,
+            argument_string
+          )
+          |> Base.encode16()
+
+        {:ok, "#{url}?#{argument_string}&signature=#{signature}", headers}
+    end
+  end
+
+  def post_binance(url, params) do
+    body = sign_body(params)
+
+    case HTTPoison.post("#{@endpoint}#{url}", body, [
+           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)}
+         ]) do
+      {:error, err} ->
+        {:error, {:http_error, err}}
+
+      {:ok, response} ->
+        case Poison.decode(response.body) do
+          {:ok, data} -> {:ok, data}
+          {:error, err} -> {:error, {:poison_decode_error, err}}
+        end
+    end
+  end
+
+  def put_binance(url, params) do
+    body = sign_body(params)
+
+    case HTTPoison.put("#{@endpoint}#{url}", body, [
+           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)}
+         ]) do
+      {:error, err} ->
+        {:error, {:http_error, err}}
+
+      {:ok, %{body: ""}} ->
+        {:ok, ""}
+
+      {:ok, response} ->
+        case Poison.decode(response.body) do
+          {:ok, data} -> {:ok, data}
+          {:error, err} -> {:error, {:poison_decode_error, err}}
+        end
+    end
+  end
+
+  defp validate_credentials(nil, nil),
+    do: {:error, {:config_missing, "Secret and API key missing"}}
+
+  defp validate_credentials(nil, _api_key), do: {:error, {:config_missing, "Secret key missing"}}
+
+  defp validate_credentials(_secret_key, nil), do: {:error, {:config_missing, "API key missing"}}
+
+  defp validate_credentials(_secret_key, _api_key), do: :ok
+
+  defp parse_response({:ok, response}) do
+    response.body
+    |> Poison.decode()
+    |> parse_response_body
+  end
+
+  defp parse_response({:error, err}) do
+    {:error, {:http_error, err}}
+  end
+
+  defp parse_response_body({:ok, data}) do
+    case data do
+      %{"code" => _c, "msg" => _m} = error -> {:error, error}
+      _ -> {:ok, data}
+    end
+  end
+
+  defp parse_response_body({:error, err}) do
+    {:error, {:poison_decode_error, err}}
+  end
+
+  defp sign_body(params) do
+    argument_string =
+      params
+      |> Map.to_list()
+      |> Enum.map(fn x -> Tuple.to_list(x) |> Enum.join("=") end)
+      |> Enum.join("&")
+
+    signature =
+      :crypto.hmac(
+        :sha256,
+        Application.get_env(:binance, :secret_key),
+        argument_string
+      )
+      |> Base.encode16()
+
+    "#{argument_string}&signature=#{signature}"
+  end
+end

--- a/lib/binance/futures/websocket/ws_client.ex
+++ b/lib/binance/futures/websocket/ws_client.ex
@@ -1,0 +1,155 @@
+defmodule Binance.Futures.WebSocket.WSClient do
+  @moduledoc """
+  WebSocket client for Binance Futures
+
+  There are 2 types of WebSocket channels/streams on Binance:
+
+  - Public streams (https://binanceapitest.github.io/Binance-Futures-API-doc/wss/)
+  - User Data streams (https://binanceapitest.github.io/Binance-Futures-API-doc/userdatastream/)
+
+  Use the `require_auth` option to indicate if we're going to subscribe to User Data stream or not.
+  If we're not, use `public_channels` to list out channels/streams we would like to subscribe to.
+  Or said it in other way, `public_channels` will be ignored when `require_auth` is `true`.
+
+  Usage example:
+
+  defmodule A do
+    use Binance.Futures.WebSocket.WSClient
+  end
+
+  # Public channels/streams
+  A.start_link(%{name: :"btcusdt-depth-stream", public_channels: ["btcusdt@depth"]})
+
+  # User Data stream
+  A.start_link(%{name: :"user-data-stream", require_auth: true})
+  """
+
+  import Logger, only: [info: 1, warn: 1]
+  import Process, only: [send_after: 3]
+
+  # Client API
+  defmacro __using__(_opts) do
+    quote do
+      use WebSockex
+      alias ExOkex.Config
+      @base Application.get_env(:binance, :ws_endpoint, "wss://fstream.binance.com")
+      @ping_interval Application.get_env(:binance, :ping_interval, 5_000)
+      @keep_alive_interval Application.get_env(:binance, :keep_alive_interval, 10 * 60_000)
+
+      def start_link(args \\ %{}) do
+        name = args[:name] || __MODULE__
+        require_auth = args[:require_auth] || false
+        public_channels = args[:public_channels]
+        state = Map.merge(args, %{heartbeat: 0, listen_key: nil})
+
+        if require_auth == true do
+          {:ok, %{"listenKey" => listen_key}} = Binance.Futures.create_listen_key()
+          state = Map.merge(state, %{listen_key: listen_key})
+          endpoint_url = prepare_endpoint_url(listen_key)
+          WebSockex.start_link(endpoint_url, __MODULE__, state, name: name)
+        else
+          endpoint_url = prepare_endpoint_url(public_channels)
+          WebSockex.start_link(endpoint_url, __MODULE__, state, name: name)
+        end
+      end
+
+      def schedule_keep_alive_stream() do
+        send_after(self(), :keep_alive, 10_000)
+      end
+
+      def handle_info(:keep_alive, state) do
+        {:ok, %{}} = Binance.Futures.keep_alive_listen_key()
+        schedule_keep_alive_stream()
+        {:ok, state}
+      end
+
+      def prepare_endpoint_url(stream_name) when is_binary(stream_name) do
+        @base <> "/ws/" <> stream_name
+      end
+
+      def prepare_endpoint_url(stream_names) when is_list(stream_names) do
+        @base <> "/stream?streams=" <> Enum.join(stream_names, "/")
+      end
+
+      # Callbacks
+
+      def handle_pong(:pong, state) do
+        {:ok, inc_heartbeat(state)}
+      end
+
+      def handle_connect(_conn, state) do
+        :ok = info("Binance Connected!")
+        send_after(self(), {:heartbeat, :ping, 1}, 20_000)
+        {:ok, state}
+      end
+
+      def handle_info({:ws_reply, frame}, state) do
+        {:reply, frame, state}
+      end
+
+      def handle_info(
+            {:heartbeat, :ping, expected_heartbeat},
+            %{heartbeat: heartbeat} = state
+          ) do
+        if heartbeat >= expected_heartbeat do
+          send_after(self(), {:heartbeat, :ping, heartbeat + 1}, 1_000)
+          {:ok, state}
+        else
+          send_after(self(), {:heartbeat, :pong, heartbeat + 1}, 4_000)
+          {:reply, :ping, state}
+        end
+      end
+
+      def handle_info(
+            {:heartbeat, :pong, expected_heartbeat},
+            %{heartbeat: heartbeat} = state
+          ) do
+        if heartbeat >= expected_heartbeat do
+          send_after(self(), {:heartbeat, :ping, heartbeat + 1}, 1_000)
+          {:ok, state}
+        else
+          :ok = warn("#{__MODULE__} terminated due to " <> "no heartbeat ##{heartbeat}")
+          {:close, state}
+        end
+      end
+
+      @doc """
+      Handles pong response from the Binance
+      """
+      def handle_frame({:binary, <<43, 200, 207, 75, 7, 0>> = pong}, state) do
+        pong
+        |> :zlib.unzip()
+        |> handle_response(state |> inc_heartbeat())
+      end
+
+      def handle_frame({:text, json_data}, state) do
+        response = json_data |> Jason.decode!()
+        handle_response(response, state)
+      end
+
+      def handle_response(resp, state) do
+        :ok = info("#{__MODULE__} received response: #{inspect(resp)}")
+        {:ok, state}
+      end
+
+      def handle_disconnect(resp, state) do
+        :ok = info("Binance Disconnected! #{inspect(resp)}")
+        {:ok, state}
+      end
+
+      def terminate({:local, :normal}, %{catch_terminate: pid}),
+        do: send(pid, :normal_close_terminate)
+
+      def terminate(_, %{catch_terminate: pid}), do: send(pid, :terminate)
+      def terminate(_, _), do: :ok
+
+      # Helpers
+
+      defp inc_heartbeat(%{heartbeat: heartbeat} = state) do
+        Map.put(state, :heartbeat, heartbeat + 1)
+      end
+
+      defoverridable handle_connect: 2, handle_disconnect: 2, handle_response: 2
+    end
+  end
+end

--- a/lib/binance/rest/http_client.ex
+++ b/lib/binance/rest/http_client.ex
@@ -96,14 +96,11 @@ defmodule Binance.Rest.HTTPClient do
   defp validate_credentials(nil, nil),
     do: {:error, {:config_missing, "Secret and API key missing"}}
 
-  defp validate_credentials(nil, _api_key),
-    do: {:error, {:config_missing, "Secret key missing"}}
+  defp validate_credentials(nil, _api_key), do: {:error, {:config_missing, "Secret key missing"}}
 
-  defp validate_credentials(_secret_key, nil),
-    do: {:error, {:config_missing, "API key missing"}}
+  defp validate_credentials(_secret_key, nil), do: {:error, {:config_missing, "API key missing"}}
 
-  defp validate_credentials(_secret_key, _api_key),
-    do: :ok
+  defp validate_credentials(_secret_key, _api_key), do: :ok
 
   defp parse_response({:ok, response}) do
     response.body

--- a/mix.exs
+++ b/mix.exs
@@ -28,6 +28,7 @@ defmodule Binance.MixProject do
       {:httpoison, "~> 1.0"},
       {:poison, "~> 4.0.0"},
       {:exconstructor, "~> 1.1.0"},
+      {:websockex, "~> 0.4.2"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:mix_test_watch, "~> 0.5", only: :dev, runtime: false},
       {:exvcr, "~> 0.10.1", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -23,4 +23,5 @@
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  "websockex": {:hex, :websockex, "0.4.2", "9a3b7dc25655517ecd3f8ff7109a77fce94956096b942836cdcfbc7c86603ecc", [:mix], [], "hexpm"},
 }

--- a/test/futures_test.exs
+++ b/test/futures_test.exs
@@ -1,0 +1,179 @@
+defmodule FuturesTest do
+  use ExUnit.Case
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
+  doctest Binance
+
+  setup_all do
+    HTTPoison.start()
+  end
+
+  test "ping returns an empty map" do
+    use_cassette "futures/ping_ok" do
+      assert Binance.Futures.ping() == {:ok, %{}}
+    end
+  end
+
+  test "get_server_time success return an ok, time tuple" do
+    use_cassette "futures/get_server_time_ok" do
+      assert Binance.Futures.get_server_time() == {:ok, 1_568_879_218_176}
+    end
+  end
+
+  test "get_exchange_info success returns the trading rules and symbol information" do
+    use_cassette "futures/get_exchange_info_ok" do
+      assert {:ok, %Binance.ExchangeInfo{} = info} = Binance.Futures.get_exchange_info()
+      assert info.timezone == "UTC"
+      assert info.server_time != nil
+
+      assert info.rate_limits == [
+               %{
+                 "interval" => "MINUTE",
+                 "limit" => 1200,
+                 "rateLimitType" => "REQUEST_WEIGHT",
+                 "intervalNum" => 1
+               },
+               %{
+                 "interval" => "MINUTE",
+                 "intervalNum" => 1,
+                 "limit" => 600,
+                 "rateLimitType" => "ORDERS"
+               }
+             ]
+
+      assert info.exchange_filters == []
+      assert [symbol | _] = info.symbols
+
+      assert symbol == %{
+               "baseAsset" => "BTC",
+               "baseAssetPrecision" => 8,
+               "filters" => [
+                 %{
+                   "filterType" => "PRICE_FILTER",
+                   "maxPrice" => "100000",
+                   "minPrice" => "0.01",
+                   "tickSize" => "0.01"
+                 },
+                 %{
+                   "filterType" => "LOT_SIZE",
+                   "maxQty" => "1000",
+                   "minQty" => "0.001",
+                   "stepSize" => "0.001"
+                 },
+                 %{
+                   "filterType" => "MARKET_LOT_SIZE",
+                   "maxQty" => "1000",
+                   "minQty" => "0.001",
+                   "stepSize" => "0.001"
+                 },
+                 %{"filterType" => "MAX_NUM_ORDERS", "limit" => 0},
+                 %{
+                   "filterType" => "PERCENT_PRICE",
+                   "multiplierDecimal" => "4",
+                   "multiplierDown" => "0.8500",
+                   "multiplierUp" => "1.1500"
+                 }
+               ],
+               "maintMarginPercent" => "2.5000",
+               "orderTypes" => ["LIMIT", "MARKET", "STOP"],
+               "pricePrecision" => 2,
+               "quantityPrecision" => 3,
+               "quoteAsset" => "USDT",
+               "quotePrecision" => 8,
+               "requiredMarginPercent" => "5.0000",
+               "status" => "TRADING",
+               "symbol" => "BTCUSDT",
+               "timeInForce" => ["GTC", "IOC", "FOK", "GTX"]
+             }
+    end
+  end
+
+  describe ".create_listen_key" do
+    test "returns a listen key which could be used to subscrbe to a User Data stream" do
+      use_cassette "futures/create_listen_key_ok" do
+        assert Binance.Futures.create_listen_key() == {
+                 :ok,
+                 %{
+                   "listenKey" =>
+                     "SHKiq1MSr119hfs4ZB6EZWkdikAPq8RGVuQGdGMnvvUUmaeZygVcoO1CchfzXeCd"
+                 }
+               }
+      end
+    end
+  end
+
+  describe ".keep_alive_listen_key" do
+    test "returns empty indicating the given listen key has been keepalive successfully" do
+      use_cassette "futures/keep_alive_listen_key_ok" do
+        assert Binance.Futures.keep_alive_listen_key() == {:ok, ""}
+      end
+    end
+  end
+
+  describe ".get_depth" do
+    test "returns the bids & asks up to the given depth" do
+      use_cassette "futures/get_depth_ok" do
+        assert Binance.Futures.get_depth("BTCUSDT", 5) == {
+                 :ok,
+                 %Binance.OrderBook{
+                   asks: [
+                     ["9876.71", "2.569"],
+                     ["9877.08", "1.745"],
+                     ["9877.48", "1.743"],
+                     ["9878.15", "1.580"],
+                     ["9878.36", "3.091"]
+                   ],
+                   bids: [
+                     ["9875.74", "1.849"],
+                     ["9875.59", "2.752"],
+                     ["9875.16", "2.588"],
+                     ["9874.67", "1.547"],
+                     ["9873.80", "3.647"]
+                   ],
+                   last_update_id: 36_154_698
+                 }
+               }
+      end
+    end
+
+    test "returns an error tuple when the symbol doesn't exist" do
+      use_cassette "get_depth_error" do
+        assert Binance.get_depth("IDONTEXIST", 1000) == {
+                 :error,
+                 %{"code" => -1121, "msg" => "Invalid symbol."}
+               }
+      end
+    end
+  end
+
+  describe ".get_account" do
+    test "returns current account information" do
+      use_cassette "futures/get_account_ok" do
+        assert Binance.Futures.get_account() == {
+                 :ok,
+                 %Binance.Futures.Account{
+                   assets: [
+                     %{
+                       "asset" => "USDT",
+                       "initialMargin" => "0.00000000",
+                       "maintMargin" => "0.00000000",
+                       "marginBalance" => "10.18000000",
+                       "unrealizedProfit" => "0.00000000",
+                       "walletBalance" => "10.18000000"
+                     }
+                   ],
+                   can_deposit: true,
+                   can_trade: true,
+                   can_withdraw: true,
+                   fee_tier: 0,
+                   total_initial_margin: "0.00000000",
+                   total_maint_margin: "0.00000000",
+                   total_margin_balance: "10.18000000",
+                   total_unrealized_profit: "0.00000000",
+                   total_wallet_balance: "10.18000000",
+                   update_time: 0
+                 }
+               }
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add a REST APIs client for Binance Futures with some basic actions: `ping`, `get_server_time`, `get_exchange_info`, `create_listen_key`, `keep_alive_listen_key`, `get_depth` and `get_account`.

- Add another WebSocket client for Binance Futures

References: https://binanceapitest.github.io/Binance-Futures-API-doc