### PR TITLE
Support some Order APIs for Binance Futures

### DIFF
--- a/fixture/vcr_cassettes/futures/cancel_non_existing_order.json
+++ b/fixture/vcr_cassettes/futures/cancel_non_existing_order.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order?orderId=123456&recvWindow=5000&symbol=BTCUSDT&timestamp=1568995697788&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"status\":\"REJECTED\",\"reduceOnly\":false,\"updateTime\":1568995698674402579,\"rejectReason\":\"UNKNOWN_ORDER\"}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "104",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 16:08:18 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "5ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 c967a8805fdfaef2a31a279939e3cfec.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG54-C1",
+        "X-Amz-Cf-Id": "fb_eWYrEMkG7P1ZZWUjtci_6IO3DKZeAgCXfDcDzpGLio5NDHmybIw=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/cancel_order_by_client_order_id_ok.json
+++ b/fixture/vcr_cassettes/futures/cancel_order_by_client_order_id_ok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order?origClientOrderId=Slo0A5UZBOWK7cdUNVUsfO&recvWindow=5000&symbol=BTCUSDT&timestamp=1568995555802&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"orderId\":11277192,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"CANCELED\",\"clientOrderId\":\"Slo0A5UDDOWK7cdUNVUsfO\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568996656841}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "308",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 16:05:56 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "6ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 abe726b1571439a6268136ea3851d873.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG54-C1",
+        "X-Amz-Cf-Id": "HZmfm77i55o9DOpGh7azcGUPxqA8_lSPS4VH6PAXLLipvThg2ZyFJw=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/cancel_order_by_exchange_order_id_ok.json
+++ b/fixture/vcr_cassettes/futures/cancel_order_by_exchange_order_id_ok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "delete",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order?orderId=11257530&recvWindow=5000&symbol=BTCUSDT&timestamp=1568995337209&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"orderId\":11222530,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"CANCELED\",\"clientOrderId\":\"wgQyWAlBFCCWinOy7yPFDu\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568999338577}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "308",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 16:02:18 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "6ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 4cd19ffd43f53635451d728efb012d71.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG53",
+        "X-Amz-Cf-Id": "vvk0A6Hov8u-SNowZpPLP8wvVz_N2jwNQ52Qol57ZLwbKtp5j6gm5A=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_open_orders_with_symbol_string_success.json
+++ b/fixture/vcr_cassettes/futures/get_open_orders_with_symbol_string_success.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/openOrders?recvWindow=5000&symbol=BTCUSDT&timestamp=1568997891742&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "[{\"orderId\":11333637,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"kFVoo0nClhOku6KbcB8B1X\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568995541781}]",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "292",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 16:44:52 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "1ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 920ad0b17d673466d3e5b0603a6da31c.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG53",
+        "X-Amz-Cf-Id": "pk88RU0pcN8yAsN_X9JoKxI3GLxGO-bcsIAh7fSPFjmR5vcbOPQIDA=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_open_orders_without_symbol_success.json
+++ b/fixture/vcr_cassettes/futures/get_open_orders_without_symbol_success.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/openOrders?recvWindow=5000&timestamp=1568997285742&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "[{\"orderId\":11377637,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"kFVOX0nClhOku6TTcB8B1X\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568997441781},{\"orderId\":18821005,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"qVG9BiiCkLqfvVqhHnVurH\",\"price\":\"9000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"BUY\",\"stopPrice\":\"0\",\"updateTime\":1568007063660}]",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "581",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 16:34:46 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "1ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 373c716feb96dba95431972bb1105837.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG54-C1",
+        "X-Amz-Cf-Id": "9iidLg5KhUirX8dQHM9cuQbkTpDvywAA5KAKltQ8RfiwCVJXVjgL-A=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_order_by_client_order_id_ok.json
+++ b/fixture/vcr_cassettes/futures/get_order_by_client_order_id_ok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order?origClientOrderId=F1YDd11xJvGWNiBbt7JCrr&recvWindow=5000&symbol=BTCUSDT&timestamp=1568979844645&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"orderId\":10926974,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"F1YDd19xJvGWNiBbt7JCrr\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568988806336}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 11:44:05 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "3ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 ad0287f9f263e70aa0a52b05ac6ca798.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG54-C1",
+        "X-Amz-Cf-Id": "d4kgjYvo_JzxbFo0D7kLAnja0_mJUp_Kr0hfYzbLwWAnI1BjlYtRwQ=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_order_by_exchange_order_id_ok.json
+++ b/fixture/vcr_cassettes/futures/get_order_by_exchange_order_id_ok.json
@@ -1,0 +1,37 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order?orderId=10926974&recvWindow=5000&symbol=BTCUSDT&timestamp=1568979550048&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"orderId\":10926974,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"F1YDd19xJvGWNiBbt7JCrr\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568988806336}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "290",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 11:39:11 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "11ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 03bf93293c59fa009ef6917600948bb3.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG53",
+        "X-Amz-Cf-Id": "JZd0Re6tL3kARWz4tY4B97VzGxqhHRzo8CMu6Ed6CPalpyljb7Ki8A=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/get_order_error.json
+++ b/fixture/vcr_cassettes/futures/get_order_error.json
@@ -1,0 +1,34 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "get",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order?orderId=123456789&recvWindow=5000&symbol=BTCUSDT&timestamp=1568979376562&signature=***"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"code\":-2013,\"msg\":\"Order does not exist.\"}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "44",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 11:36:17 GMT",
+        "Server": "Tengine",
+        "x-response-time": "3ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "X-Cache": "Error from cloudfront",
+        "Via": "1.1 5ba8379cda77812559800b5a5c101994.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG53",
+        "X-Amz-Cf-Id": "b8XjToRSbc7_GnKaWw_JynoRE3Mvd5p4WNNIi_zOA1bH5AfMPab_HA=="
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/order_limit_buy_error_insufficient_balance.json
+++ b/fixture/vcr_cassettes/futures/order_limit_buy_error_insufficient_balance.json
@@ -1,0 +1,35 @@
+[
+  {
+    "request": {
+      "body": "price=9000&quantity=0.05&recvWindow=1000&side=BUY&symbol=BTCUSDT&timeInForce=GTC&timestamp=1568970933859&type=LIMIT&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"code\":-1000,\"msg\":\"You don't have enough margin for this new order\"}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "70",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 09:15:34 GMT",
+        "Server": "Tengine",
+        "x-response-time": "6ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "X-Cache": "Error from cloudfront",
+        "Via": "1.1 6510d9494672c245cbfa38f2c21c782a.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "5bUYgR77sXZVff2rCQiXpMMTnn-9Ve54FnnUR34uGbhBs77T20DDAQ=="
+      },
+      "status_code": 400,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/order_limit_buy_good_til_cancel_default_duration_success.json
+++ b/fixture/vcr_cassettes/futures/order_limit_buy_good_til_cancel_default_duration_success.json
@@ -1,0 +1,38 @@
+[
+  {
+    "request": {
+      "body": "price=9000&quantity=0.001&recvWindow=1000&side=BUY&symbol=BTCUSDT&timeInForce=GTC&timestamp=1568970694511&type=LIMIT&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"orderId\":10817219,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"NZzeeQSqS5PH5OS9WAMBIy\",\"price\":\"9000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"BUY\",\"stopPrice\":\"0\",\"updateTime\":1568970695368}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "301",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 09:11:35 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "5ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 472637409b8ae00cf91bae609bb7b3ae.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "APSWbdeJ85Zy2RmwevYYQf-Db04jWAvPSGwNIpCIQztQh3PtE5kRaA=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/order_limit_sell_good_til_cancel_default_duration_success.json
+++ b/fixture/vcr_cassettes/futures/order_limit_sell_good_til_cancel_default_duration_success.json
@@ -1,0 +1,38 @@
+[
+  {
+    "request": {
+      "body": "price=11000&quantity=0.001&recvWindow=1000&side=SELL&symbol=BTCUSDT&timeInForce=GTC&timestamp=1568976216026&type=LIMIT&signature=***",
+      "headers": {
+        "X-MBX-APIKEY": "***",
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://fapi.binance.com/fapi/v1/order"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"orderId\":10800687,\"symbol\":\"BTCUSDT\",\"accountId\":1000,\"status\":\"NEW\",\"clientOrderId\":\"VV0vLLVnABzLXwYxvDkYqF\",\"price\":\"11000\",\"origQty\":\"0.001\",\"executedQty\":\"0\",\"cumQty\":\"0\",\"cumQuote\":\"0\",\"timeInForce\":\"GTC\",\"type\":\"LIMIT\",\"reduceOnly\":false,\"side\":\"SELL\",\"stopPrice\":\"0\",\"updateTime\":1568976216827}",
+      "headers": {
+        "Content-Type": "application/json",
+        "Content-Length": "303",
+        "Connection": "keep-alive",
+        "Date": "Fri, 20 Sep 2019 10:43:36 GMT",
+        "Server": "Tengine",
+        "Vary": "Accept-Encoding",
+        "x-response-time": "5ms",
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        "Access-Control-Allow-Credentials": "true",
+        "Access-Control-Allow-Headers": "*,clienttype,Content-Type,lang,x-ui-request-trace",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 ceabec403784e3c3155b50578b3935fd.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "HKG60-C1",
+        "X-Amz-Cf-Id": "yFRG59V-d5--YlCJ_94Y4vxKoWeeMZJb9IBbBZXTRv-Px69CuHGq_w=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/binance/futures.ex
+++ b/lib/binance/futures.ex
@@ -1,6 +1,9 @@
 defmodule Binance.Futures do
   alias Binance.Futures.Rest.HTTPClient
 
+  @api_key Application.get_env(:binance, :api_key)
+  @secret_key Application.get_env(:binance, :secret_key)
+
   # Server
 
   @doc """
@@ -136,10 +139,7 @@ defmodule Binance.Futures do
   """
 
   def get_account() do
-    api_key = Application.get_env(:binance, :api_key)
-    secret_key = Application.get_env(:binance, :secret_key)
-
-    case HTTPClient.get_binance("/fapi/v1/account", %{}, secret_key, api_key) do
+    case HTTPClient.get_binance("/fapi/v1/account", %{}, @secret_key, @api_key) do
       {:ok, data} ->
         {:ok, Binance.Futures.Account.new(data)}
 
@@ -262,20 +262,19 @@ defmodule Binance.Futures do
   Read more: https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#current-open-orders-user_data
   """
   def get_open_orders() do
-    api_key = Application.get_env(:binance, :api_key)
-    secret_key = Application.get_env(:binance, :secret_key)
-
-    case HTTPClient.get_binance("/fapi/v1/openOrders", %{}, secret_key, api_key) do
+    case HTTPClient.get_binance("/fapi/v1/openOrders", %{}, @secret_key, @api_key) do
       {:ok, data} -> {:ok, Enum.map(data, &Binance.Futures.Order.new(&1))}
       err -> err
     end
   end
 
   def get_open_orders(symbol) when is_binary(symbol) do
-    api_key = Application.get_env(:binance, :api_key)
-    secret_key = Application.get_env(:binance, :secret_key)
-
-    case HTTPClient.get_binance("/fapi/v1/openOrders", %{:symbol => symbol}, secret_key, api_key) do
+    case HTTPClient.get_binance(
+           "/fapi/v1/openOrders",
+           %{:symbol => symbol},
+           @secret_key,
+           @api_key
+         ) do
       {:ok, data} -> {:ok, Enum.map(data, &Binance.Futures.Order.new(&1))}
       err -> err
     end
@@ -302,9 +301,6 @@ defmodule Binance.Futures do
       )
       when is_binary(symbol)
       when is_integer(order_id) or is_binary(orig_client_order_id) do
-    api_key = Application.get_env(:binance, :api_key)
-    secret_key = Application.get_env(:binance, :secret_key)
-
     arguments =
       %{
         symbol: symbol
@@ -318,7 +314,7 @@ defmodule Binance.Futures do
         )
       )
 
-    case HTTPClient.get_binance("/fapi/v1/order", arguments, secret_key, api_key) do
+    case HTTPClient.get_binance("/fapi/v1/order", arguments, @secret_key, @api_key) do
       {:ok, data} -> {:ok, Binance.Futures.Order.new(data)}
       err -> err
     end
@@ -342,9 +338,6 @@ defmodule Binance.Futures do
       )
       when is_binary(symbol)
       when is_integer(order_id) or is_binary(orig_client_order_id) do
-    api_key = Application.get_env(:binance, :api_key)
-    secret_key = Application.get_env(:binance, :secret_key)
-
     arguments =
       %{
         symbol: symbol
@@ -358,7 +351,7 @@ defmodule Binance.Futures do
         )
       )
 
-    case HTTPClient.delete_binance("/fapi/v1/order", arguments, secret_key, api_key) do
+    case HTTPClient.delete_binance("/fapi/v1/order", arguments, @secret_key, @api_key) do
       {:ok, %{"rejectReason" => _} = err} -> {:error, err}
       {:ok, data} -> {:ok, Binance.Futures.Order.new(data)}
       err -> err

--- a/lib/binance/futures/order.ex
+++ b/lib/binance/futures/order.ex
@@ -1,4 +1,4 @@
-defmodule Binance.Futures.OrderResponse do
+defmodule Binance.Futures.Order do
   defstruct [
     :client_order_id,
     :cum_qty,

--- a/lib/binance/futures/order_response.ex
+++ b/lib/binance/futures/order_response.ex
@@ -1,0 +1,21 @@
+defmodule Binance.Futures.OrderResponse do
+  defstruct [
+    :client_order_id,
+    :cum_qty,
+    :cum_quote,
+    :executed_qty,
+    :order_id,
+    :orig_qty,
+    :price,
+    :reduce_only,
+    :side,
+    :status,
+    :stop_price,
+    :symbol,
+    :time_in_force,
+    :type,
+    :update_time
+  ]
+
+  use ExConstructor
+end

--- a/test/futures_test.exs
+++ b/test/futures_test.exs
@@ -305,4 +305,62 @@ defmodule FuturesTest do
       end
     end
   end
+
+  describe ".cancel_order" do
+    test "cancel an order by exchange order id" do
+      use_cassette "futures/cancel_order_by_exchange_order_id_ok" do
+        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+                 Binance.Futures.cancel_order("BTCUSDT", 11_257_530)
+
+        assert response.client_order_id == "wgQyWAlBFCCWinOy7yPFDu"
+        assert response.cum_quote == "0"
+        assert response.executed_qty == "0"
+        assert response.order_id == 11_222_530
+        assert response.orig_qty == "0.001"
+        assert response.price == "11000"
+        assert response.reduce_only == false
+        assert response.side == "SELL"
+        assert response.status == "CANCELED"
+        assert response.stop_price == "0"
+        assert response.symbol == "BTCUSDT"
+        assert response.time_in_force == "GTC"
+        assert response.type == "LIMIT"
+        assert response.update_time == 1_568_999_338_577
+      end
+    end
+
+    test "cancel an order by client order id" do
+      use_cassette "futures/cancel_order_by_client_order_id_ok" do
+        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+                 Binance.Futures.cancel_order("BTCUSDT", nil, "Slo0A5UDDOWK7cdUNVUsfO")
+
+        assert response.client_order_id == "Slo0A5UDDOWK7cdUNVUsfO"
+        assert response.cum_quote == "0"
+        assert response.executed_qty == "0"
+        assert response.order_id == 11_277_192
+        assert response.orig_qty == "0.001"
+        assert response.price == "11000"
+        assert response.reduce_only == false
+        assert response.side == "SELL"
+        assert response.status == "CANCELED"
+        assert response.stop_price == "0"
+        assert response.symbol == "BTCUSDT"
+        assert response.time_in_force == "GTC"
+        assert response.type == "LIMIT"
+        assert response.update_time == 1_568_996_656_841
+      end
+    end
+
+    test "return errors when cancel an non-existing order" do
+      use_cassette "futures/cancel_non_existing_order" do
+        assert {:error,
+                %{
+                  "reduceOnly" => false,
+                  "rejectReason" => "UNKNOWN_ORDER",
+                  "status" => "REJECTED",
+                  "updateTime" => 1_568_995_698_674_402_579
+                }} = Binance.Futures.cancel_order("BTCUSDT", 123_456)
+      end
+    end
+  end
 end

--- a/test/futures_test.exs
+++ b/test/futures_test.exs
@@ -252,4 +252,57 @@ defmodule FuturesTest do
       end
     end
   end
+
+  describe ".get_order" do
+    test "gets an order information by exchange order id" do
+      use_cassette "futures/get_order_by_exchange_order_id_ok" do
+        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+                 Binance.Futures.get_order("BTCUSDT", 10_926_974)
+
+        assert response.client_order_id == "F1YDd19xJvGWNiBbt7JCrr"
+        assert response.cum_quote == "0"
+        assert response.executed_qty == "0"
+        assert response.order_id == 10_926_974
+        assert response.orig_qty == "0.001"
+        assert response.price == "11000"
+        assert response.reduce_only == false
+        assert response.side == "SELL"
+        assert response.status == "NEW"
+        assert response.stop_price == "0"
+        assert response.symbol == "BTCUSDT"
+        assert response.time_in_force == "GTC"
+        assert response.type == "LIMIT"
+        assert response.update_time == 1_568_988_806_336
+      end
+    end
+
+    test "gets an order information by client order id" do
+      use_cassette "futures/get_order_by_client_order_id_ok" do
+        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+                 Binance.Futures.get_order("BTCUSDT", nil, "F1YDd11xJvGWNiBbt7JCrr")
+
+        assert response.client_order_id == "F1YDd19xJvGWNiBbt7JCrr"
+        assert response.cum_quote == "0"
+        assert response.executed_qty == "0"
+        assert response.order_id == 10_926_974
+        assert response.orig_qty == "0.001"
+        assert response.price == "11000"
+        assert response.reduce_only == false
+        assert response.side == "SELL"
+        assert response.status == "NEW"
+        assert response.stop_price == "0"
+        assert response.symbol == "BTCUSDT"
+        assert response.time_in_force == "GTC"
+        assert response.type == "LIMIT"
+        assert response.update_time == 1_568_988_806_336
+      end
+    end
+
+    test "returns an insufficient margin error tuple" do
+      use_cassette "futures/get_order_error" do
+        assert {:error, %{"code" => -2013, "msg" => "Order does not exist."} = _reason} =
+                 Binance.Futures.get_order("BTCUSDT", 123_456_789)
+      end
+    end
+  end
 end

--- a/test/futures_test.exs
+++ b/test/futures_test.exs
@@ -176,4 +176,80 @@ defmodule FuturesTest do
       end
     end
   end
+
+  describe ".order_limit_buy" do
+    test "creates an order with a duration of good til cancel by default" do
+      use_cassette "futures/order_limit_buy_good_til_cancel_default_duration_success" do
+        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+                 Binance.Futures.order_limit_buy("BTCUSDT", 0.001, 9000)
+
+        assert response.client_order_id == "NZzeeQSqS5PH5OS9WAMBIy"
+        assert response.cum_qty == "0"
+        assert response.cum_quote == "0"
+        assert response.executed_qty == "0"
+        assert response.order_id == 10_817_219
+        assert response.orig_qty == "0.001"
+        assert response.price == "9000"
+        assert response.reduce_only == false
+        assert response.side == "BUY"
+        assert response.status == "NEW"
+        assert response.stop_price == "0"
+        assert response.symbol == "BTCUSDT"
+        assert response.time_in_force == "GTC"
+        assert response.type == "LIMIT"
+        assert response.update_time == 1_568_970_695_368
+      end
+    end
+
+    test "returns an insufficient margin error tuple" do
+      use_cassette "futures/order_limit_buy_error_insufficient_balance" do
+        assert {:error, reason} = Binance.Futures.order_limit_buy("BTCUSDT", 0.05, 9000)
+
+        assert reason == %Binance.InsufficientBalanceError{
+                 reason: %{
+                   code: -1000,
+                   msg: "You don't have enough margin for this new order"
+                 }
+               }
+      end
+    end
+  end
+
+  describe ".order_limit_sell" do
+    test "creates an order with a duration of good til cancel by default" do
+      use_cassette "futures/order_limit_sell_good_til_cancel_default_duration_success" do
+        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+                 Binance.Futures.order_limit_sell("BTCUSDT", 0.001, 11000)
+
+        assert response.client_order_id == "VV0vLLVnABzLXwYxvDkYqF"
+        assert response.cum_qty == "0"
+        assert response.cum_quote == "0"
+        assert response.executed_qty == "0"
+        assert response.order_id == 10_800_687
+        assert response.orig_qty == "0.001"
+        assert response.price == "11000"
+        assert response.reduce_only == false
+        assert response.side == "SELL"
+        assert response.status == "NEW"
+        assert response.stop_price == "0"
+        assert response.symbol == "BTCUSDT"
+        assert response.time_in_force == "GTC"
+        assert response.type == "LIMIT"
+        assert response.update_time == 1_568_976_216_827
+      end
+    end
+
+    test "returns an insufficient margin error tuple" do
+      use_cassette "futures/order_limit_buy_error_insufficient_balance" do
+        assert {:error, reason} = Binance.Futures.order_limit_sell("BTCUSDT", 0.05, 11000)
+
+        assert reason == %Binance.InsufficientBalanceError{
+                 reason: %{
+                   code: -1000,
+                   msg: "You don't have enough margin for this new order"
+                 }
+               }
+      end
+    end
+  end
 end

--- a/test/futures_test.exs
+++ b/test/futures_test.exs
@@ -180,7 +180,7 @@ defmodule FuturesTest do
   describe ".order_limit_buy" do
     test "creates an order with a duration of good til cancel by default" do
       use_cassette "futures/order_limit_buy_good_til_cancel_default_duration_success" do
-        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+        assert {:ok, %Binance.Futures.Order{} = response} =
                  Binance.Futures.order_limit_buy("BTCUSDT", 0.001, 9000)
 
         assert response.client_order_id == "NZzeeQSqS5PH5OS9WAMBIy"
@@ -218,7 +218,7 @@ defmodule FuturesTest do
   describe ".order_limit_sell" do
     test "creates an order with a duration of good til cancel by default" do
       use_cassette "futures/order_limit_sell_good_til_cancel_default_duration_success" do
-        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+        assert {:ok, %Binance.Futures.Order{} = response} =
                  Binance.Futures.order_limit_sell("BTCUSDT", 0.001, 11000)
 
         assert response.client_order_id == "VV0vLLVnABzLXwYxvDkYqF"
@@ -253,10 +253,74 @@ defmodule FuturesTest do
     end
   end
 
+  describe ".get_open_orders" do
+    test "when called without symbol returns all open orders for all symbols" do
+      use_cassette "futures/get_open_orders_without_symbol_success" do
+        assert {:ok,
+                [
+                  %Binance.Futures.Order{} = order_1,
+                  %Binance.Futures.Order{} = order_2
+                ]} = Binance.Futures.get_open_orders()
+
+        assert order_1.client_order_id == "kFVOX0nClhOku6TTcB8B1X"
+        assert order_1.cum_quote == "0"
+        assert order_1.executed_qty == "0"
+        assert order_1.order_id == 11_377_637
+        assert order_1.orig_qty == "0.001"
+        assert order_1.price == "11000"
+        assert order_1.reduce_only == false
+        assert order_1.side == "SELL"
+        assert order_1.status == "NEW"
+        assert order_1.stop_price == "0"
+        assert order_1.symbol == "BTCUSDT"
+        assert order_1.time_in_force == "GTC"
+        assert order_1.type == "LIMIT"
+        assert order_1.update_time == 1_568_997_441_781
+
+        assert order_2.client_order_id == "qVG9BiiCkLqfvVqhHnVurH"
+        assert order_2.cum_quote == "0"
+        assert order_2.executed_qty == "0"
+        assert order_2.order_id == 18_821_005
+        assert order_2.orig_qty == "0.001"
+        assert order_2.price == "9000"
+        assert order_2.reduce_only == false
+        assert order_2.side == "BUY"
+        assert order_2.status == "NEW"
+        assert order_2.stop_price == "0"
+        assert order_2.symbol == "BTCUSDT"
+        assert order_2.time_in_force == "GTC"
+        assert order_2.type == "LIMIT"
+        assert order_2.update_time == 1_568_007_063_660
+      end
+    end
+
+    test "when called with symbol returns all open orders for that symbols(string)" do
+      use_cassette "futures/get_open_orders_with_symbol_string_success" do
+        assert {:ok, [%Binance.Futures.Order{} = order_1]} =
+                 Binance.Futures.get_open_orders("BTCUSDT")
+
+        assert order_1.client_order_id == "kFVoo0nClhOku6KbcB8B1X"
+        assert order_1.cum_quote == "0"
+        assert order_1.executed_qty == "0"
+        assert order_1.order_id == 11_333_637
+        assert order_1.orig_qty == "0.001"
+        assert order_1.price == "11000"
+        assert order_1.reduce_only == false
+        assert order_1.side == "SELL"
+        assert order_1.status == "NEW"
+        assert order_1.stop_price == "0"
+        assert order_1.symbol == "BTCUSDT"
+        assert order_1.time_in_force == "GTC"
+        assert order_1.type == "LIMIT"
+        assert order_1.update_time == 1_568_995_541_781
+      end
+    end
+  end
+
   describe ".get_order" do
     test "gets an order information by exchange order id" do
       use_cassette "futures/get_order_by_exchange_order_id_ok" do
-        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+        assert {:ok, %Binance.Futures.Order{} = response} =
                  Binance.Futures.get_order("BTCUSDT", 10_926_974)
 
         assert response.client_order_id == "F1YDd19xJvGWNiBbt7JCrr"
@@ -278,7 +342,7 @@ defmodule FuturesTest do
 
     test "gets an order information by client order id" do
       use_cassette "futures/get_order_by_client_order_id_ok" do
-        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+        assert {:ok, %Binance.Futures.Order{} = response} =
                  Binance.Futures.get_order("BTCUSDT", nil, "F1YDd11xJvGWNiBbt7JCrr")
 
         assert response.client_order_id == "F1YDd19xJvGWNiBbt7JCrr"
@@ -309,7 +373,7 @@ defmodule FuturesTest do
   describe ".cancel_order" do
     test "cancel an order by exchange order id" do
       use_cassette "futures/cancel_order_by_exchange_order_id_ok" do
-        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+        assert {:ok, %Binance.Futures.Order{} = response} =
                  Binance.Futures.cancel_order("BTCUSDT", 11_257_530)
 
         assert response.client_order_id == "wgQyWAlBFCCWinOy7yPFDu"
@@ -331,7 +395,7 @@ defmodule FuturesTest do
 
     test "cancel an order by client order id" do
       use_cassette "futures/cancel_order_by_client_order_id_ok" do
-        assert {:ok, %Binance.Futures.OrderResponse{} = response} =
+        assert {:ok, %Binance.Futures.Order{} = response} =
                  Binance.Futures.cancel_order("BTCUSDT", nil, "Slo0A5UDDOWK7cdUNVUsfO")
 
         assert response.client_order_id == "Slo0A5UDDOWK7cdUNVUsfO"


### PR DESCRIPTION
Support some APIs:

- [Create new orders](https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#new-order-trade)

- [Query an order](https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#query-order-user_data)

- [Cancel an order](https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#cancel-order-trade)

- [Get current open orders](https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#current-open-orders-user_data)