### PR TITLE
Support WebSocket for Binance Spot trading

### DIFF
--- a/fixture/vcr_cassettes/create_listen_key_ok.json
+++ b/fixture/vcr_cassettes/create_listen_key_ok.json
@@ -1,0 +1,45 @@
+[
+  {
+    "request": {
+      "body": "",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.binance.com/api/v1/userDataStream"
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"listenKey\":\"l6oKmHZzY6CGcO7PlGehRO3NStJgPMMON7899c1xs6qYGKBfqPjbEw9hZlf5\"}",
+      "headers": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "Date": "Mon, 23 Sep 2019 09:11:11 GMT",
+        "Server": "nginx",
+        "Vary": "Accept-Encoding",
+        "X-MBX-UUID": "55b8df0c-a986-4657-85a0-00c4793ebd90",
+        "X-MBX-USED-WEIGHT": "1",
+        "X-MBX-USED-WEIGHT-1M": "1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Xss-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Security-Policy": "default-src 'self'",
+        "X-Content-Security-Policy": "default-src 'self'",
+        "X-WebKit-CSP": "default-src 'self'",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 a0dab1619e09a1e6e84a759dfdfe7343.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "SIN5-C1",
+        "X-Amz-Cf-Id": "7mS6gw5fG5qPF76Y5jDDK-PI0Zahttk-c2TZ1kQ8yfJGkLiqDHXzUQ=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/keep_alive_listen_key_ok.json
+++ b/fixture/vcr_cassettes/keep_alive_listen_key_ok.json
@@ -1,0 +1,45 @@
+[
+  {
+    "request": {
+      "body": "listenKey=l6oKmHZzY6CGcO7PlGehRO3NStJgPMMON7899c1xs6qYGKBfqPjbEw9hZlf5",
+      "headers": {
+        "X-MBX-APIKEY": "***"
+      },
+      "method": "put",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.binance.com/api/v1/userDataStream"
+    },
+    "response": {
+      "binary": false,
+      "body": "{}",
+      "headers": {
+        "Content-Type": "application/json;charset=utf-8",
+        "Transfer-Encoding": "chunked",
+        "Connection": "keep-alive",
+        "Date": "Mon, 23 Sep 2019 09:13:16 GMT",
+        "Server": "nginx",
+        "Vary": "Accept-Encoding",
+        "X-MBX-UUID": "dd6bd317-2ece-450d-b70a-4e027d5a9256",
+        "X-MBX-USED-WEIGHT": "1",
+        "X-MBX-USED-WEIGHT-1M": "1",
+        "Strict-Transport-Security": "max-age=31536000; includeSubdomains",
+        "X-Frame-Options": "SAMEORIGIN",
+        "X-Xss-Protection": "1; mode=block",
+        "X-Content-Type-Options": "nosniff",
+        "Content-Security-Policy": "default-src 'self'",
+        "X-Content-Security-Policy": "default-src 'self'",
+        "X-WebKit-CSP": "default-src 'self'",
+        "Cache-Control": "no-cache, no-store, must-revalidate",
+        "Pragma": "no-cache",
+        "Expires": "0",
+        "X-Cache": "Miss from cloudfront",
+        "Via": "1.1 e869415928b7de75c30c1dc3da361401.cloudfront.net (CloudFront)",
+        "X-Amz-Cf-Pop": "SIN5-C1",
+        "X-Amz-Cf-Id": "Ach_sqA5yRsXG760vfIaZkl7PaRhT9WIkq_2pYDqpisF41uPjVgSlg=="
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/lib/binance.ex
+++ b/lib/binance.ex
@@ -35,6 +35,54 @@ defmodule Binance do
     end
   end
 
+  @doc """
+  Start a new user data stream. The stream will close after 60 minutes unless a keepalive is sent.
+
+  Returns `{:ok, time}` if successful, `{:error, reason}` otherwise
+
+  ## Example response
+  ```
+  {
+    "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
+  }
+  ```
+
+  """
+  def create_listen_key() do
+    case HTTPClient.post_binance("/api/v1/userDataStream", %{}) do
+      {:ok, %{"code" => code, "msg" => msg}} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}}
+
+      data ->
+        data
+    end
+  end
+
+  @doc """
+  Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.
+
+  Returns `{:ok, time}` if successful, `{:error, reason}` otherwise
+
+  ## Example response
+  ```
+  {}
+  ```
+
+  """
+  def keep_alive_listen_key(listen_key) do
+    arguments = %{
+      listenKey: listen_key
+    }
+
+    case HTTPClient.put_binance("/api/v1/userDataStream", arguments) do
+      {:ok, %{"code" => code, "msg" => msg}} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}}
+
+      data ->
+        data
+    end
+  end
+
   # Ticker
 
   @doc """
@@ -597,7 +645,8 @@ defmodule Binance do
         )
       )
       |> Map.merge(
-        unless(is_nil(new_client_order_id),
+        unless(
+          is_nil(new_client_order_id),
           do: %{newClientOrderId: new_client_order_id},
           else: %{}
         )

--- a/lib/binance.ex
+++ b/lib/binance.ex
@@ -47,9 +47,11 @@ defmodule Binance do
   }
   ```
 
+  Note: Binance Spot does not require us to sign this request body while this very same API on Binance Futures does
+
   """
   def create_listen_key() do
-    case HTTPClient.post_binance("/api/v1/userDataStream", %{}) do
+    case HTTPClient.post_binance("/api/v1/userDataStream", %{}, false) do
       {:ok, %{"code" => code, "msg" => msg}} ->
         {:error, {:binance_error, %{code: code, msg: msg}}}
 
@@ -68,13 +70,15 @@ defmodule Binance do
   {}
   ```
 
+  Note: Binance Spot does not require us to sign this request body while this very same API on Binance Futures does
+
   """
   def keep_alive_listen_key(listen_key) do
     arguments = %{
       listenKey: listen_key
     }
 
-    case HTTPClient.put_binance("/api/v1/userDataStream", arguments) do
+    case HTTPClient.put_binance("/api/v1/userDataStream", arguments, false) do
       {:ok, %{"code" => code, "msg" => msg}} ->
         {:error, {:binance_error, %{code: code, msg: msg}}}
 

--- a/lib/binance/futures/rest/http_client.ex
+++ b/lib/binance/futures/rest/http_client.ex
@@ -66,8 +66,7 @@ defmodule Binance.Futures.Rest.HTTPClient do
   end
 
   def post_binance(url, params) do
-    # Binance does require us to sign this request
-    body = Util.prepare_request_body(params, true)
+    body = Util.prepare_request_body(params)
 
     case HTTPoison.post("#{@endpoint}#{url}", body, [
            {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
@@ -85,8 +84,7 @@ defmodule Binance.Futures.Rest.HTTPClient do
   end
 
   def put_binance(url, params) do
-    # Binance does require us to sign this request
-    body = Util.prepare_request_body(params, true)
+    body = Util.prepare_request_body(params)
 
     case HTTPoison.put("#{@endpoint}#{url}", body, [
            {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},

--- a/lib/binance/futures/rest/http_client.ex
+++ b/lib/binance/futures/rest/http_client.ex
@@ -66,12 +66,10 @@ defmodule Binance.Futures.Rest.HTTPClient do
   end
 
   def post_binance(url, params) do
+    headers = Util.prepare_request_headers(:post)
     body = Util.prepare_request_body(params)
 
-    case HTTPoison.post("#{@endpoint}#{url}", body, [
-           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
-           {"Content-Type", "application/x-www-form-urlencoded"}
-         ]) do
+    case HTTPoison.post("#{@endpoint}#{url}", body, headers) do
       {:error, err} ->
         {:error, {:http_error, err}}
 
@@ -84,12 +82,10 @@ defmodule Binance.Futures.Rest.HTTPClient do
   end
 
   def put_binance(url, params) do
+    headers = Util.prepare_request_headers(:put)
     body = Util.prepare_request_body(params)
 
-    case HTTPoison.put("#{@endpoint}#{url}", body, [
-           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
-           {"Content-Type", "application/x-www-form-urlencoded"}
-         ]) do
+    case HTTPoison.put("#{@endpoint}#{url}", body, headers) do
       {:error, err} ->
         {:error, {:http_error, err}}
 

--- a/lib/binance/futures/websocket/ws_client.ex
+++ b/lib/binance/futures/websocket/ws_client.ex
@@ -80,7 +80,7 @@ defmodule Binance.Futures.WebSocket.WSClient do
       end
 
       def handle_connect(_conn, state) do
-        :ok = info("Binance Connected!")
+        :ok = info("Binance Futures Connected!")
         send_after(self(), {:heartbeat, :ping, 1}, 20_000)
 
         # If this is User Data stream, schedule a process to keepalive the stream every 10mins (see @keep_alive_interval)
@@ -148,7 +148,7 @@ defmodule Binance.Futures.WebSocket.WSClient do
       end
 
       def handle_disconnect(resp, state) do
-        :ok = info("Binance Disconnected! #{inspect(resp)}")
+        :ok = info("Binance Futures Disconnected! #{inspect(resp)}")
         {:ok, state}
       end
 

--- a/lib/binance/rest/http_client.ex
+++ b/lib/binance/rest/http_client.ex
@@ -64,12 +64,10 @@ defmodule Binance.Rest.HTTPClient do
   end
 
   def post_binance(url, params, signed? \\ true) do
+    headers = Util.prepare_request_headers(:post)
     body = Util.prepare_request_body(params, signed: signed?)
 
-    case HTTPoison.post("#{@endpoint}#{url}", body, [
-           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
-           {"Content-Type", "application/x-www-form-urlencoded"}
-         ]) do
+    case HTTPoison.post("#{@endpoint}#{url}", body, headers) do
       {:error, err} ->
         {:error, {:http_error, err}}
 
@@ -82,12 +80,10 @@ defmodule Binance.Rest.HTTPClient do
   end
 
   def put_binance(url, params, signed? \\ true) do
+    headers = Util.prepare_request_headers(:put)
     body = Util.prepare_request_body(params, signed: signed?)
 
-    case HTTPoison.put("#{@endpoint}#{url}", body, [
-           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
-           {"Content-Type", "application/x-www-form-urlencoded"}
-         ]) do
+    case HTTPoison.put("#{@endpoint}#{url}", body, headers) do
       {:error, err} ->
         {:error, {:http_error, err}}
 

--- a/lib/binance/rest/http_client.ex
+++ b/lib/binance/rest/http_client.ex
@@ -63,12 +63,12 @@ defmodule Binance.Rest.HTTPClient do
     end
   end
 
-  def post_binance(url, params) do
-    # Binance does not require us to sign this request
-    body = Util.prepare_request_body(params, false)
+  def post_binance(url, params, signed? \\ true) do
+    body = Util.prepare_request_body(params, signed: signed?)
 
     case HTTPoison.post("#{@endpoint}#{url}", body, [
-           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)}
+           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
+           {"Content-Type", "application/x-www-form-urlencoded"}
          ]) do
       {:error, err} ->
         {:error, {:http_error, err}}
@@ -81,12 +81,12 @@ defmodule Binance.Rest.HTTPClient do
     end
   end
 
-  def put_binance(url, params) do
-    # Binance does not require us to sign this request
-    body = Util.prepare_request_body(params, false)
+  def put_binance(url, params, signed? \\ true) do
+    body = Util.prepare_request_body(params, signed: signed?)
 
     case HTTPoison.put("#{@endpoint}#{url}", body, [
-           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)}
+           {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
+           {"Content-Type", "application/x-www-form-urlencoded"}
          ]) do
       {:error, err} ->
         {:error, {:http_error, err}}

--- a/lib/binance/util.ex
+++ b/lib/binance/util.ex
@@ -23,6 +23,19 @@ defmodule Binance.Util do
     end
   end
 
+  def prepare_request_headers(method) when method in [:post, :put] do
+    [
+      {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)},
+      {"Content-Type", "application/x-www-form-urlencoded"}
+    ]
+  end
+
+  def prepare_request_headers(_) do
+    [
+      {"X-MBX-APIKEY", Application.get_env(:binance, :api_key)}
+    ]
+  end
+
   defp sign_content(content) do
     :crypto.hmac(
       :sha256,

--- a/lib/binance/util.ex
+++ b/lib/binance/util.ex
@@ -4,14 +4,16 @@ defmodule Binance.Util do
   @doc """
   Prepare request body, sign it if required
   """
-  def prepare_request_body(params, sign?) do
+  def prepare_request_body(params, opts \\ []) do
+    signed? = Keyword.get(opts, :signed, true)
+
     argument_string =
       params
       |> Map.to_list()
       |> Enum.map(fn x -> Tuple.to_list(x) |> Enum.join("=") end)
       |> Enum.join("&")
 
-    case sign? do
+    case signed? do
       true ->
         signature = sign_content(argument_string)
         "#{argument_string}&signature=#{signature}"
@@ -21,10 +23,7 @@ defmodule Binance.Util do
     end
   end
 
-  @doc """
-  Sign a value using Binance Secret key
-  """
-  def sign_content(content) do
+  defp sign_content(content) do
     :crypto.hmac(
       :sha256,
       Application.get_env(:binance, :secret_key),

--- a/lib/binance/util.ex
+++ b/lib/binance/util.ex
@@ -1,0 +1,35 @@
+defmodule Binance.Util do
+  @moduledoc false
+
+  @doc """
+  Prepare request body, sign it if required
+  """
+  def prepare_request_body(params, sign?) do
+    argument_string =
+      params
+      |> Map.to_list()
+      |> Enum.map(fn x -> Tuple.to_list(x) |> Enum.join("=") end)
+      |> Enum.join("&")
+
+    case sign? do
+      true ->
+        signature = sign_content(argument_string)
+        "#{argument_string}&signature=#{signature}"
+
+      false ->
+        argument_string
+    end
+  end
+
+  @doc """
+  Sign a value using Binance Secret key
+  """
+  def sign_content(content) do
+    :crypto.hmac(
+      :sha256,
+      Application.get_env(:binance, :secret_key),
+      content
+    )
+    |> Base.encode16()
+  end
+end

--- a/lib/binance/websocket/ws_client.ex
+++ b/lib/binance/websocket/ws_client.ex
@@ -1,0 +1,170 @@
+defmodule Binance.WebSocket.WSClient do
+  @moduledoc """
+  WebSocket client for Binance Spot
+
+  There are 2 types of WebSocket channels/streams for Spot trading on Binance:
+
+  - [Public streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md)
+  - [User Data stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/user-data-stream.md)
+
+  Use the `require_auth` option to indicate if we're going to subscribe to User Data stream or not.
+  If we're not, use `public_channels` to list out channels/streams we would like to subscribe to.
+  Or said it in other way, `public_channels` will be ignored when `require_auth` is `true`.
+
+  Note: User Data stream requires to have a listen key created beforehand. A listen key needs
+  to be keepalive every 30 mins otherwise the stream would be closed after 30mins. This WebSocket client
+  by default sets the interval time for keepalive the stream to be 10mins (see @keep_alive_interval)
+
+  Also, this WebSocket client maintains a heartbeat mechanism by sending a ping every 5_000ms (see @ping interval)
+  to check if the WebSocket server is in connected and to decide whether to continue to keep the connection or
+  terminate the current one and start a new one.
+
+  Usage example:
+
+  defmodule A do
+    use Binance.WebSocket.WSClient
+  end
+
+  # Public channels/streams
+  A.start_link(%{name: :"btcusdt-depth-stream", public_channels: ["btcusdt@depth"]})
+
+  # User Data stream
+  A.start_link(%{name: :"user-data-stream", require_auth: true})
+  """
+
+  import Logger, only: [info: 1, warn: 1]
+  import Process, only: [send_after: 3]
+
+  # Client API
+  defmacro __using__(_opts) do
+    quote do
+      use WebSockex
+      alias ExOkex.Config
+      @base Application.get_env(:binance, :ws_endpoint, "wss://stream.binance.com:9443")
+      @ping_interval Application.get_env(:binance, :ping_interval, 5_000)
+      @keep_alive_interval Application.get_env(:binance, :keep_alive_interval, 10 * 60_000)
+
+      def start_link(args \\ %{}) do
+        name = args[:name] || __MODULE__
+        require_auth = args[:require_auth] || false
+        public_channels = args[:public_channels]
+        state = Map.merge(args, %{heartbeat: 0, listen_key: nil})
+
+        if require_auth == true do
+          {:ok, %{"listenKey" => listen_key}} = Binance.create_listen_key()
+          state = Map.merge(state, %{listen_key: listen_key})
+          endpoint_url = prepare_endpoint_url(listen_key)
+          WebSockex.start_link(endpoint_url, __MODULE__, state, name: name)
+        else
+          endpoint_url = prepare_endpoint_url(public_channels)
+          WebSockex.start_link(endpoint_url, __MODULE__, state, name: name)
+        end
+      end
+
+      def schedule_keep_alive_stream() do
+        send_after(self(), :keep_alive, @keep_alive_interval)
+      end
+
+      def prepare_endpoint_url(stream_name) when is_binary(stream_name) do
+        @base <> "/ws/" <> stream_name
+      end
+
+      def prepare_endpoint_url(stream_names) when is_list(stream_names) do
+        @base <> "/stream?streams=" <> Enum.join(stream_names, "/")
+      end
+
+      # Callbacks
+
+      def handle_pong(:pong, state) do
+        {:ok, inc_heartbeat(state)}
+      end
+
+      def handle_connect(_conn, state) do
+        :ok = info("Binance Spot Connected!")
+        send_after(self(), {:heartbeat, :ping, 1}, 20_000)
+
+        # If this is User Data stream, schedule a process to keepalive the stream every 10mins (see @keep_alive_interval)
+        if state.listen_key do
+          schedule_keep_alive_stream()
+        end
+
+        {:ok, state}
+      end
+
+      def handle_info(:keep_alive, state) do
+        {:ok, _} = Binance.keep_alive_listen_key()
+        :ok = info("Keepalive Binance's User Data stream done!")
+        schedule_keep_alive_stream()
+        {:ok, state}
+      end
+
+      def handle_info({:ws_reply, frame}, state) do
+        {:reply, frame, state}
+      end
+
+      def handle_info(
+            {:heartbeat, :ping, expected_heartbeat},
+            %{heartbeat: heartbeat} = state
+          ) do
+        if heartbeat >= expected_heartbeat do
+          send_after(self(), {:heartbeat, :ping, heartbeat + 1}, 1_000)
+          {:ok, state}
+        else
+          send_after(self(), {:heartbeat, :pong, heartbeat + 1}, 4_000)
+          {:reply, :ping, state}
+        end
+      end
+
+      def handle_info(
+            {:heartbeat, :pong, expected_heartbeat},
+            %{heartbeat: heartbeat} = state
+          ) do
+        if heartbeat >= expected_heartbeat do
+          send_after(self(), {:heartbeat, :ping, heartbeat + 1}, 1_000)
+          {:ok, state}
+        else
+          :ok = warn("#{__MODULE__} terminated due to " <> "no heartbeat ##{heartbeat}")
+          {:close, state}
+        end
+      end
+
+      @doc """
+      Handles pong response from the Binance
+      """
+      def handle_frame({:binary, <<43, 200, 207, 75, 7, 0>> = pong}, state) do
+        pong
+        |> :zlib.unzip()
+        |> handle_response(state |> inc_heartbeat())
+      end
+
+      def handle_frame({:text, json_data}, state) do
+        response = json_data |> Jason.decode!()
+        handle_response(response, state)
+      end
+
+      def handle_response(resp, state) do
+        :ok = info("#{__MODULE__} received response: #{inspect(resp)}")
+        {:ok, state}
+      end
+
+      def handle_disconnect(resp, state) do
+        :ok = info("Binance Spot Disconnected! #{inspect(resp)}")
+        {:ok, state}
+      end
+
+      def terminate({:local, :normal}, %{catch_terminate: pid}),
+        do: send(pid, :normal_close_terminate)
+
+      def terminate(_, %{catch_terminate: pid}), do: send(pid, :terminate)
+      def terminate(_, _), do: :ok
+
+      # Helpers
+
+      defp inc_heartbeat(%{heartbeat: heartbeat} = state) do
+        Map.put(state, :heartbeat, heartbeat + 1)
+      end
+
+      defoverridable handle_connect: 2, handle_disconnect: 2, handle_response: 2
+    end
+  end
+end

--- a/test/binance_test.exs
+++ b/test/binance_test.exs
@@ -101,6 +101,29 @@ defmodule BinanceTest do
     end
   end
 
+  describe ".create_listen_key" do
+    test "returns a listen key which could be used to subscrbe to a User Data stream" do
+      use_cassette "create_listen_key_ok" do
+        assert Binance.create_listen_key() == {
+                 :ok,
+                 %{
+                   "listenKey" => "l6oKmHZzY6CGcO7PlGehRO3NStJgPMMON7899c1xs6qYGKBfqPjbEw9hZlf5"
+                 }
+               }
+      end
+    end
+  end
+
+  describe ".keep_alive_listen_key" do
+    test "returns empty indicating the given listen key has been keepalive successfully" do
+      use_cassette "keep_alive_listen_key_ok" do
+        assert Binance.keep_alive_listen_key(
+                 "l6oKmHZzY6CGcO7PlGehRO3NStJgPMMON7899c1xs6qYGKBfqPjbEw9hZlf5"
+               ) == {:ok, %{}}
+      end
+    end
+  end
+
   describe ".get_depth" do
     test "returns the bids & asks up to the given depth" do
       use_cassette "get_depth_ok" do
@@ -434,7 +457,7 @@ defmodule BinanceTest do
         assert order.executed_qty == "0.00000000"
         assert order.iceberg_qty == nil
         assert order.is_working == nil
-        assert order.order_id == 212217782
+        assert order.order_id == 212_217_782
         assert order.orig_qty == "100.00000000"
         assert order.price == "0.30000000"
         assert order.side == "BUY"


### PR DESCRIPTION
Support WebSocket for Binance's [WebSocket streams](https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md) and [User Data stream](https://github.com/binance-exchange/binance-official-api-docs/blob/master/user-data-stream.md)

Usage example:

```
defmodule A do
  use Binance.WebSocket.WSClient
end

# Public channels/streams
A.start_link(%{name: :"btcusdt-depth-stream", public_channels: ["btcusdt@depth"]})

# User Data stream
A.start_link(%{name: :"user-data-stream", require_auth: true})