### PR TITLE
Capture "userAssets" field in Cross Margin Account response

### DIFF
--- a/lib/binance/margin/account.ex
+++ b/lib/binance/margin/account.ex
@@ -10,7 +10,8 @@ defmodule Binance.Margin.Account do
     :total_liability_of_btc,
     :total_net_asset_of_btc,
     :trade_enabled,
-    :transfer_enabled
+    :transfer_enabled,
+    :user_assets
   ]
 
   use ExConstructor


### PR DESCRIPTION
https://binance-docs.github.io/apidocs/spot/en/#query-cross-margin-account-details-user_data

Capture `userAssets` field in response of [Cross Margin Account API](https://binance-docs.github.io/apidocs/spot/en/#query-cross-margin-account-details-user_data).