### PR TITLE
Support Isolated Margin's Accounts APIs and capture "positions" field in Futures Account response

### DIFF
--- a/lib/binance/futures/account.ex
+++ b/lib/binance/futures/account.ex
@@ -30,6 +30,7 @@ defmodule Binance.Futures.Account do
     :can_withdraw,
     :can_deposit,
     :assets,
+    :positions,
     :update_time
   ]
 

--- a/lib/binance/margin.ex
+++ b/lib/binance/margin.ex
@@ -71,6 +71,16 @@ defmodule Binance.Margin do
     end
   end
 
+  def get_isolated_account(params \\ %{}, config \\ nil) do
+    case HTTPClient.get_binance("/sapi/v1/margin/isolated/account", params, config) do
+      {:ok, data} ->
+        {:ok, Binance.Margin.IsolatedAccount.new(data)}
+
+      error ->
+        error
+    end
+  end
+
   def get_index_price(instrument, config \\ nil) do
     case HTTPClient.get_binance("/sapi/v1/margin/priceIndex", %{symbol: instrument}, config) do
       {:ok, data} -> {:ok, data}

--- a/lib/binance/margin/isolated_account.ex
+++ b/lib/binance/margin/isolated_account.ex
@@ -1,0 +1,14 @@
+defmodule Binance.Margin.IsolatedAccount do
+  @moduledoc """
+  Struct for representing a result row as returned by /sapi/v1/margin/isolated/account
+  """
+
+  defstruct [
+    :total_asset_of_btc,
+    :total_liability_of_btc,
+    :total_net_asset_of_btc,
+    :assets
+  ]
+
+  use ExConstructor
+end


### PR DESCRIPTION
- Capture "positions" field in Futures Account response.
- Support [Isolated Margin Accounts APIs](https://binance-docs.github.io/apidocs/spot/en/#query-isolated-margin-account-info-user_data) (`GET /sapi/v1/margin/isolated/account`).