### PR TITLE
Return headers for all apis

### DIFF
--- a/lib/binance.ex
+++ b/lib/binance.ex
@@ -12,7 +12,7 @@ defmodule Binance do
   @doc """
   Pings binance API
   """
-  @spec ping() :: {:ok, %{}} | {:error, error()}
+  @spec ping() :: {:ok, %{}, any()} | {:error, error()}
   def ping() do
     HTTPClient.get_binance("/api/v3/ping")
   end
@@ -26,26 +26,26 @@ defmodule Binance do
   ```
 
   """
-  @spec get_server_time() :: {:ok, integer()} | {:error, error()}
+  @spec get_server_time() :: {:ok, integer(), any()} | {:error, error()}
   def get_server_time() do
     case HTTPClient.get_binance("/api/v3/time") do
-      {:ok, %{"serverTime" => time}} -> {:ok, time}
+      {:ok, %{"serverTime" => time}, headers} -> {:ok, time, headers}
       err -> err
     end
   end
 
-  @spec get_exchange_info() :: {:ok, %Binance.ExchangeInfo{}} | {:error, error()}
+  @spec get_exchange_info() :: {:ok, %Binance.ExchangeInfo{}, any()} | {:error, error()}
   def get_exchange_info() do
     case HTTPClient.get_binance("/api/v3/exchangeInfo") do
-      {:ok, data} -> {:ok, Binance.ExchangeInfo.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.ExchangeInfo.new(data), headers}
       err -> err
     end
   end
 
-  @spec get_best_ticker(String.t()) :: {:ok, map()} | {:error, error()}
+  @spec get_best_ticker(String.t()) :: {:ok, map(), any()} | {:error, error()}
   def get_best_ticker(instrument) do
     case HTTPClient.get_binance("/api/v3/ticker/bookTicker?symbol=#{instrument}") do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
@@ -63,11 +63,11 @@ defmodule Binance do
   Note: Binance Spot does not require us to sign this request body while this very same API on Binance Futures does
 
   """
-  @spec create_listen_key(map() | nil) :: {:ok, map()} | {:error, error()}
+  @spec create_listen_key(map() | nil) :: {:ok, map(), any()} | {:error, error()}
   def create_listen_key(config \\ nil) do
     case HTTPClient.post_binance("/api/v3/userDataStream", %{}, config, false) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -92,8 +92,8 @@ defmodule Binance do
     }
 
     case HTTPClient.put_binance("/api/v3/userDataStream", arguments, config, false) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -119,10 +119,10 @@ defmodule Binance do
       weighted_avg_price: "0.06946930"}}
   ```
   """
-  @spec get_ticker(String.t()) :: {:ok, %Binance.Ticker{}} | {:error, error()}
+  @spec get_ticker(String.t()) :: {:ok, %Binance.Ticker{}, any()} | {:error, error()}
   def get_ticker(symbol) when is_binary(symbol) do
     case HTTPClient.get_binance("/api/v3/ticker/24hr?symbol=#{symbol}") do
-      {:ok, data} -> {:ok, Binance.Ticker.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.Ticker.new(data), headers}
       err -> err
     end
   end
@@ -153,10 +153,10 @@ defmodule Binance do
   }
   ```
   """
-  @spec get_depth(String.t(), integer()) :: {:ok, %Binance.OrderBook{}} | {:error, error()}
+  @spec get_depth(String.t(), integer()) :: {:ok, %Binance.OrderBook{}, any()} | {:error, error()}
   def get_depth(symbol, limit) do
     case HTTPClient.get_binance("/api/v3/depth?symbol=#{symbol}&limit=#{limit}") do
-      {:ok, data} -> {:ok, Binance.OrderBook.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.OrderBook.new(data), headers}
       err -> err
     end
   end
@@ -174,7 +174,7 @@ defmodule Binance do
   @spec get_account(map() | nil) :: {:ok, %Binance.Account{}} | {:error, error()}
   def get_account(config \\ nil) do
     case HTTPClient.get_binance("/api/v3/account", %{}, config) do
-      {:ok, data} -> {:ok, Binance.Account.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.Account.new(data), headers}
       error -> error
     end
   end
@@ -186,7 +186,7 @@ defmodule Binance do
 
   Please read https://www.binance.com/restapipub.html#user-content-account-endpoints to understand all the parameters
   """
-  @spec create_order(map(), map() | nil) :: {:ok, map()} | {:error, error()}
+  @spec create_order(map(), map() | nil) :: {:ok, map(), any()} | {:error, error()}
   def create_order(
         %{symbol: symbol, side: side, type: type, quantity: quantity} = params,
         config \\ nil
@@ -231,8 +231,8 @@ defmodule Binance do
       )
 
     case HTTPClient.post_binance("/api/v3/order", arguments, config) do
-      {:ok, data} ->
-        {:ok, Binance.OrderResponse.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.OrderResponse.new(data), headers}
 
       error ->
         error
@@ -260,10 +260,10 @@ defmodule Binance do
      ...]}
   ```
   """
-  @spec get_open_orders(map(), map() | nil) :: {:ok, list(%Binance.Order{})} | {:error, error()}
+  @spec get_open_orders(map(), map() | nil) :: {:ok, list(%Binance.Order{}), any()} | {:error, error()}
   def get_open_orders(params \\ %{}, config \\ nil) do
     case HTTPClient.get_binance("/api/v3/openOrders", params, config) do
-      {:ok, data} -> {:ok, Enum.map(data, &Binance.Order.new(&1))}
+      {:ok, data, headers} -> {:ok, Enum.map(data, &Binance.Order.new(&1)), headers}
       err -> err
     end
   end
@@ -304,7 +304,7 @@ defmodule Binance do
       )
 
     case HTTPClient.get_binance("/api/v3/order", arguments, config) do
-      {:ok, data} -> {:ok, Binance.Order.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.Order.new(data), headers}
       err -> err
     end
   end
@@ -351,15 +351,15 @@ defmodule Binance do
       )
 
     case HTTPClient.delete_binance("/api/v3/order", arguments, config) do
-      {:ok, data} -> {:ok, Binance.Order.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.Order.new(data), headers}
       err -> err
     end
   end
 
   def cancel_all_orders(params, config \\ nil) do
     case HTTPClient.delete_binance("/api/v3/openOrders", params, config) do
-      {:ok, %{"rejectReason" => _} = err} -> {:error, err}
-      {:ok, data} -> {:ok, Binance.Order.new(data)}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, Binance.Order.new(data), headers}
       err -> err
     end
   end

--- a/lib/binance/coin_futures.ex
+++ b/lib/binance/coin_futures.ex
@@ -29,46 +29,46 @@ defmodule Binance.CoinFutures do
   @spec get_server_time() :: {:ok, integer()} | {:error, error()}
   def get_server_time() do
     case HTTPClient.get_binance("/dapi/v1/time") do
-      {:ok, %{"serverTime" => time}} -> {:ok, time}
+      {:ok, %{"serverTime" => time}, headers} -> {:ok, time, headers}
       err -> err
     end
   end
 
-  @spec get_index_price(String.t()) :: {:ok, map()} | {:error, error()}
+  @spec get_index_price(String.t()) :: {:ok, map(), any()} | {:error, error()}
   def get_index_price(instrument) do
     case HTTPClient.get_binance("/dapi/v1/premiumIndex?symbol=#{instrument}") do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_best_ticker(String.t()) :: {:ok, map()} | {:error, error()}
+  @spec get_best_ticker(String.t()) :: {:ok, map(), any()} | {:error, error()}
   def get_best_ticker(instrument) do
     case HTTPClient.get_binance("/dapi/v1/ticker/bookTicker?symbol=#{instrument}") do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_kline_data(String.t(), String.t(), number) :: {:ok, map()} | {:error, error()}
+  @spec get_kline_data(String.t(), String.t(), number) :: {:ok, map(), any()} | {:error, error()}
   def get_kline_data(instrument, interval, limit) do
     case HTTPClient.get_binance(
            "/dapi/v1/klines?symbol=#{instrument}&interval=#{interval}&limit=#{limit}"
          ) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
   @spec get_continious_kline_data(String.t(), String.t(), String.t(), number) ::
-          {:ok, map()} | {:error, error()}
+          {:ok, map(), any()} | {:error, error()}
   def get_continious_kline_data(instrument, interval, contract_type, limit) do
     case HTTPClient.get_binance(
            "/dapi/v1/continuousKlines?pair=#{instrument}&interval=#{interval}&limit=#{limit}&contractType=#{
              contract_type
            }"
          ) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
@@ -76,12 +76,12 @@ defmodule Binance.CoinFutures do
   @spec get_exchange_info() :: {:ok, %Binance.ExchangeInfo{}} | {:error, error()}
   def get_exchange_info() do
     case HTTPClient.get_binance("/dapi/v1/exchangeInfo") do
-      {:ok, data} -> {:ok, Binance.ExchangeInfo.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.ExchangeInfo.new(data), headers}
       err -> err
     end
   end
 
-  @spec create_listen_key(map()) :: {:ok, map()} | {:error, error()}
+  @spec create_listen_key(map()) :: {:ok, map(), any()} | {:error, error()}
   def create_listen_key(params, config \\ nil) do
     arguments =
       %{
@@ -95,8 +95,8 @@ defmodule Binance.CoinFutures do
       )
 
     case HTTPClient.post_binance("/dapi/v1/listenKey", arguments, config) do
-      {:ok, %{"code" => code, "msg" => msg}, rate_limit} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}, rate_limit}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -118,8 +118,8 @@ defmodule Binance.CoinFutures do
       )
 
     case HTTPClient.put_binance("/dapi/v1/listenKey", arguments, config) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -155,7 +155,7 @@ defmodule Binance.CoinFutures do
   @spec get_depth(String.t(), integer) :: {:ok, %Binance.OrderBook{}} | {:error, error()}
   def get_depth(symbol, limit) do
     case HTTPClient.get_binance("/dapi/v1/depth?symbol=#{symbol}&limit=#{limit}") do
-      {:ok, data} -> {:ok, Binance.OrderBook.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.OrderBook.new(data), headers}
       err -> err
     end
   end
@@ -169,11 +169,11 @@ defmodule Binance.CoinFutures do
 
   Please read https://binance-docs.github.io/apidocs/delivery/en/#futures-account-balance-user_data
   """
-  @spec get_account(map() | nil) :: {:ok, map()} | {:error, error()}
+  @spec get_account(map() | nil) :: {:ok, map(), any()} | {:error, error()}
   def get_account(config \\ nil) do
     case HTTPClient.get_binance("/dapi/v1/account", %{}, config) do
-      {:ok, data} ->
-        {:ok, Binance.Futures.Account.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.Futures.Account.new(data), headers}
 
       error ->
         error
@@ -183,8 +183,8 @@ defmodule Binance.CoinFutures do
   @spec get_position(map() | nil) :: {:ok, list(%Binance.Futures.Position{})} | {:error, error()}
   def get_position(config \\ nil) do
     case HTTPClient.get_binance("/dapi/v1/positionRisk", %{}, config) do
-      {:ok, data} ->
-        {:ok, Enum.map(data, &Binance.Futures.Position.new(&1))}
+      {:ok, data, headers} ->
+        {:ok, Enum.map(data, &Binance.Futures.Position.new(&1)), headers}
 
       error ->
         error
@@ -200,7 +200,7 @@ defmodule Binance.CoinFutures do
 
   Please read https://binance-docs.github.io/apidocs/delivery/en/#new-order-trade
   """
-  @spec create_order(map(), map() | nil) :: {:ok, map()} | {:error, error()}
+  @spec create_order(map(), map() | nil) :: {:ok, map(), any()} | {:error, error()}
   def create_order(
         %{symbol: symbol, side: side, type: type, quantity: quantity} = params,
         config \\ nil
@@ -238,8 +238,8 @@ defmodule Binance.CoinFutures do
       )
 
     case HTTPClient.post_binance("/dapi/v1/order", arguments, config) do
-      {:ok, data, rate_limit} ->
-        {:ok, Binance.Futures.Order.new(data), rate_limit}
+      {:ok, data, headers} ->
+        {:ok, Binance.Futures.Order.new(data), headers}
 
       error ->
         error
@@ -319,10 +319,10 @@ defmodule Binance.CoinFutures do
   Read more: https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#current-open-orders-user_data
   """
   @spec get_open_orders(map(), map() | nil) ::
-          {:ok, list() | {:error, error()}}
+          {:ok, list(), any()} | {:error, error()}
   def get_open_orders(params \\ %{}, config \\ nil) do
     case HTTPClient.get_binance("/dapi/v1/openOrders", params, config) do
-      {:ok, data} -> {:ok, Enum.map(data, &Binance.Futures.Order.new(&1))}
+      {:ok, data, headers} -> {:ok, Enum.map(data, &Binance.Futures.Order.new(&1)), headers}
       err -> err
     end
   end
@@ -357,7 +357,7 @@ defmodule Binance.CoinFutures do
       )
 
     case HTTPClient.get_binance("/dapi/v1/order", arguments, config) do
-      {:ok, data} -> {:ok, Binance.Futures.Order.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.Futures.Order.new(data), headers}
       err -> err
     end
   end
@@ -367,7 +367,7 @@ defmodule Binance.CoinFutures do
 
   Symbol and either orderId or origClientOrderId must be sent.
 
-  Returns `{:ok, map()}` or `{:error, reason}`.
+  Returns `{:ok, map(), any()}` or `{:error, reason}`.
 
   Weight: 1
 
@@ -391,8 +391,8 @@ defmodule Binance.CoinFutures do
       )
 
     case HTTPClient.delete_binance("/dapi/v1/order", arguments, config) do
-      {:ok, %{"rejectReason" => _} = err, rate_limit} -> {:error, err, rate_limit}
-      {:ok, data, rate_limit} -> {:ok, Binance.Futures.Order.new(data), rate_limit}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, Binance.Futures.Order.new(data), headers}
       err -> err
     end
   end
@@ -447,8 +447,8 @@ defmodule Binance.CoinFutures do
       )
 
     case HTTPClient.delete_binance("/dapi/v1/batchOrders", arguments, config) do
-      {:ok, %{"rejectReason" => _} = err, rate_limit} -> {:error, err, rate_limit}
-      {:ok, data, rate_limit} -> {:ok, data, rate_limit}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
@@ -467,8 +467,8 @@ defmodule Binance.CoinFutures do
   @spec cancel_all_orders(map(), map() | nil) :: {:ok, any()} | {:error, any()}
   def cancel_all_orders(params, config \\ nil) do
     case HTTPClient.delete_binance("/dapi/v1/allOpenOrders", params, config) do
-      {:ok, %{"rejectReason" => _} = err, rate_limit} -> {:error, err, rate_limit}
-      {:ok, data, rate_limit} -> {:ok, data, rate_limit}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end

--- a/lib/binance/futures.ex
+++ b/lib/binance/futures.ex
@@ -12,7 +12,7 @@ defmodule Binance.Futures do
   @doc """
   Pings Binance API. Returns `{:ok, %{}}` if successful, `{:error, reason}` otherwise
   """
-  @spec ping() :: {:ok, %{}} | {:error, error()}
+  @spec ping() :: {:ok, %{}, any()} | {:error, error()}
   def ping() do
     HTTPClient.get_binance("/fapi/v1/ping")
   end
@@ -26,62 +26,62 @@ defmodule Binance.Futures do
   ```
 
   """
-  @spec get_server_time() :: {:ok, integer()} | {:error, error()}
+  @spec get_server_time() :: {:ok, integer(), any()} | {:error, error()}
   def get_server_time() do
     case HTTPClient.get_binance("/fapi/v1/time") do
-      {:ok, %{"serverTime" => time}} -> {:ok, time}
+      {:ok, %{"serverTime" => time}, headers} -> {:ok, time, headers}
       err -> err
     end
   end
 
-  @spec get_index_price(String.t()) :: {:ok, map()} | {:error, error()}
+  @spec get_index_price(String.t()) :: {:ok, map(), any()} | {:error, error()}
   def get_index_price(instrument) do
     case HTTPClient.get_binance("/fapi/v1/premiumIndex?symbol=#{instrument}") do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_best_ticker(String.t()) :: {:ok, map()} | {:error, error()}
+  @spec get_best_ticker(String.t()) :: {:ok, map(), any()} | {:error, error()}
   def get_best_ticker(instrument) do
     case HTTPClient.get_binance("/fapi/v1/ticker/bookTicker?symbol=#{instrument}") do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_kline_data(String.t(), String.t(), number) :: {:ok, map()} | {:error, error()}
+  @spec get_kline_data(String.t(), String.t(), number) :: {:ok, map(), any()} | {:error, error()}
   def get_kline_data(instrument, interval, limit) do
     case HTTPClient.get_binance(
            "/fapi/v1/klines?symbol=#{instrument}&interval=#{interval}&limit=#{limit}"
          ) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
   @spec get_continious_kline_data(String.t(), String.t(), String.t(), number) ::
-          {:ok, map()} | {:error, error()}
+          {:ok, map(), any()} | {:error, error()}
   def get_continious_kline_data(instrument, interval, contract_type, limit) do
     case HTTPClient.get_binance(
            "/fapi/v1/continuousKlines?pair=#{instrument}&interval=#{interval}&limit=#{limit}&contractType=#{
              contract_type
            }"
          ) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_exchange_info() :: {:ok, %Binance.ExchangeInfo{}} | {:error, error()}
+  @spec get_exchange_info() :: {:ok, %Binance.ExchangeInfo{}, any()} | {:error, error()}
   def get_exchange_info() do
     case HTTPClient.get_binance("/fapi/v1/exchangeInfo") do
-      {:ok, data} -> {:ok, Binance.ExchangeInfo.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.ExchangeInfo.new(data), headers}
       err -> err
     end
   end
 
-  @spec create_listen_key(map()) :: {:ok, map()} | {:error, error()}
+  @spec create_listen_key(map()) :: {:ok, map(), any()} | {:error, error()}
   def create_listen_key(params, config \\ nil) do
     arguments =
       %{
@@ -95,8 +95,8 @@ defmodule Binance.Futures do
       )
 
     case HTTPClient.post_binance("/fapi/v1/listenKey", arguments, config) do
-      {:ok, %{"code" => code, "msg" => msg}, rate_limit} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}, rate_limit}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -104,7 +104,7 @@ defmodule Binance.Futures do
   end
 
   @spec keep_alive_listen_key(map(), map() | nil) ::
-          {:ok, %{}} | {:error, error()}
+          {:ok, %{}, any()} | {:error, error()}
   def keep_alive_listen_key(params, config \\ nil) do
     arguments =
       %{
@@ -118,8 +118,8 @@ defmodule Binance.Futures do
       )
 
     case HTTPClient.put_binance("/fapi/v1/listenKey", arguments, config) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -152,10 +152,10 @@ defmodule Binance.Futures do
   }
   ```
   """
-  @spec get_depth(String.t(), integer) :: {:ok, %Binance.OrderBook{}} | {:error, error()}
+  @spec get_depth(String.t(), integer) :: {:ok, %Binance.OrderBook{}, any()} | {:error, error()}
   def get_depth(symbol, limit) do
     case HTTPClient.get_binance("/fapi/v1/depth?symbol=#{symbol}&limit=#{limit}") do
-      {:ok, data} -> {:ok, Binance.OrderBook.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.OrderBook.new(data), headers}
       err -> err
     end
   end
@@ -169,22 +169,23 @@ defmodule Binance.Futures do
 
   Please read https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/
   """
-  @spec get_account(map() | nil) :: {:ok, %Binance.Account{}} | {:error, error()}
+  @spec get_account(map() | nil) :: {:ok, %Binance.Account{}, any()} | {:error, error()}
   def get_account(config \\ nil) do
     case HTTPClient.get_binance("/fapi/v1/account", %{}, config) do
-      {:ok, data} ->
-        {:ok, Binance.Futures.Account.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.Futures.Account.new(data), headers}
 
       error ->
         error
     end
   end
 
-  @spec get_position(map() | nil) :: {:ok, list(%Binance.Futures.Position{})} | {:error, error()}
+  @spec get_position(map() | nil) ::
+          {:ok, list(%Binance.Futures.Position{}), any()} | {:error, error()}
   def get_position(config \\ nil) do
     case HTTPClient.get_binance("/fapi/v1/positionRisk", %{}, config) do
-      {:ok, data} ->
-        {:ok, Enum.map(data, &Binance.Futures.Position.new(&1))}
+      {:ok, data, headers} ->
+        {:ok, Enum.map(data, &Binance.Futures.Position.new(&1)), headers}
 
       error ->
         error
@@ -200,7 +201,7 @@ defmodule Binance.Futures do
 
   Please read https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#new-order-trade
   """
-  @spec create_order(map(), map() | nil) :: {:ok, map()} | {:error, error()}
+  @spec create_order(map(), map() | nil) :: {:ok, map(), any()} | {:error, error()}
   def create_order(
         %{symbol: symbol, side: side, type: type, quantity: quantity} = params,
         config \\ nil
@@ -238,8 +239,8 @@ defmodule Binance.Futures do
       )
 
     case HTTPClient.post_binance("/fapi/v1/order", arguments, config) do
-      {:ok, data, rate_limit} ->
-        {:ok, Binance.Futures.Order.new(data), rate_limit}
+      {:ok, data, headers} ->
+        {:ok, Binance.Futures.Order.new(data), headers}
 
       error ->
         error
@@ -319,10 +320,10 @@ defmodule Binance.Futures do
   Read more: https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#current-open-orders-user_data
   """
   @spec get_open_orders(map(), map() | nil) ::
-          {:ok, list(%Binance.Futures.Order{})} | {:error, error()}
+          {:ok, list(%Binance.Futures.Order{}), any()} | {:error, error()}
   def get_open_orders(params \\ %{}, config \\ nil) do
     case HTTPClient.get_binance("/fapi/v1/openOrders", params, config) do
-      {:ok, data} -> {:ok, Enum.map(data, &Binance.Futures.Order.new(&1))}
+      {:ok, data, headers} -> {:ok, Enum.map(data, &Binance.Futures.Order.new(&1)), headers}
       err -> err
     end
   end
@@ -339,7 +340,8 @@ defmodule Binance.Futures do
 
   Info: https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#query-order-user_data
   """
-  @spec get_order(map(), map() | nil) :: {:ok, list(%Binance.Futures.Order{})} | {:error, error()}
+  @spec get_order(map(), map() | nil) ::
+          {:ok, list(%Binance.Futures.Order{}), any()} | {:error, error()}
   def get_order(params, config \\ nil) do
     arguments =
       %{
@@ -357,7 +359,7 @@ defmodule Binance.Futures do
       )
 
     case HTTPClient.get_binance("/fapi/v1/order", arguments, config) do
-      {:ok, data} -> {:ok, Binance.Futures.Order.new(data)}
+      {:ok, data, headers} -> {:ok, Binance.Futures.Order.new(data), headers}
       err -> err
     end
   end
@@ -373,7 +375,8 @@ defmodule Binance.Futures do
 
   Info: https://binanceapitest.github.io/Binance-Futures-API-doc/trade_and_account/#cancel-order-trade
   """
-  @spec cancel_order(map(), map() | nil) :: {:ok, %Binance.Futures.Order{}} | {:error, error()}
+  @spec cancel_order(map(), map() | nil) ::
+          {:ok, %Binance.Futures.Order{}, any()} | {:error, error()}
   def cancel_order(params, config \\ nil) do
     arguments =
       %{
@@ -391,8 +394,8 @@ defmodule Binance.Futures do
       )
 
     case HTTPClient.delete_binance("/fapi/v1/order", arguments, config) do
-      {:ok, %{"rejectReason" => _} = err, rate_limit} -> {:error, err, rate_limit}
-      {:ok, data, rate_limit} -> {:ok, Binance.Futures.Order.new(data), rate_limit}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, Binance.Futures.Order.new(data), headers}
       err -> err
     end
   end
@@ -429,7 +432,7 @@ defmodule Binance.Futures do
     }
   end
 
-  @spec cancel_batch_order(map(), map() | nil) :: {:ok, list} | {:error, error()}
+  @spec cancel_batch_order(map(), map() | nil) :: {:ok, list, any()} | {:error, error()}
   def cancel_batch_order(params, config \\ nil) do
     arguments =
       %{
@@ -447,8 +450,8 @@ defmodule Binance.Futures do
       )
 
     case HTTPClient.delete_binance("/fapi/v1/batchOrders", arguments, config) do
-      {:ok, %{"rejectReason" => _} = err, rate_limit} -> {:error, err, rate_limit}
-      {:ok, data, rate_limit} -> {:ok, data, rate_limit}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
@@ -464,11 +467,11 @@ defmodule Binance.Futures do
 
   Read more: https://binance-docs.github.io/apidocs/futures/en/#cancel-all-open-orders-trade
   """
-  @spec cancel_all_orders(map(), map() | nil) :: {:ok, any()} | {:error, any()}
+  @spec cancel_all_orders(map(), map() | nil) :: {:ok, any(), any()} | {:error, any()}
   def cancel_all_orders(params, config \\ nil) do
     case HTTPClient.delete_binance("/fapi/v1/allOpenOrders", params, config) do
-      {:ok, %{"rejectReason" => _} = err, rate_limit} -> {:error, err, rate_limit}
-      {:ok, data, rate_limit} -> {:ok, data, rate_limit}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end

--- a/lib/binance/futures/coin/rest/http_client.ex
+++ b/lib/binance/futures/coin/rest/http_client.ex
@@ -1,7 +1,5 @@
 defmodule Binance.Futures.Coin.Rest.HTTPClient do
   @endpoint "https://dapi.binance.com"
-  @used_order_limit "X-MBX-ORDER-COUNT-1M"
-  @used_weight_limit "X-MBX-USED-WEIGHT-1M"
 
   alias Binance.{Config, Util}
 
@@ -12,7 +10,7 @@ defmodule Binance.Futures.Coin.Rest.HTTPClient do
 
   def delete_binance(url, headers \\ []) when is_list(headers) do
     HTTPoison.delete("#{@endpoint}#{url}", headers)
-    |> parse_response(:rate_limit)
+    |> parse_response
   end
 
   def get_binance(url, params, config) do
@@ -43,50 +41,24 @@ defmodule Binance.Futures.Coin.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.post("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            rate_limit = parse_rate_limits(err)
-            {:error, {:http_error, err}, rate_limit}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
-            rate_limit = parse_rate_limits(response)
-
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}, rate_limit}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}, rate_limit}
+                {:error, {:poison_decode_error, err}, nil}
             end
 
           {:ok, response} ->
-            rate_limit = parse_rate_limits(response)
-
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data, rate_limit}
-              {:error, err} -> {:error, {:poison_decode_error, err}, rate_limit}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, nil}
             end
         end
     end
-  end
-
-  defp parse_rate_limits(%HTTPoison.Response{headers: headers}) do
-    rates =
-      headers
-      |> Enum.reduce(
-        %{},
-        fn {k, v}, acc ->
-          case String.upcase(k) do
-            @used_order_limit -> Map.put(acc, :used_order_limit, v)
-            @used_weight_limit -> Map.put(acc, :used_weight_limit, v)
-            _ -> acc
-          end
-        end
-      )
-
-    if map_size(rates) != 0, do: rates, else: nil
-  end
-
-  defp parse_rate_limits(_) do
-    nil
   end
 
   def put_binance(url, params, config, signed? \\ true) do
@@ -97,24 +69,24 @@ defmodule Binance.Futures.Coin.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.put("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            {:error, {:http_error, err}}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}}
+                {:error, {:poison_decode_error, err}, response.headers}
             end
 
-          {:ok, %{body: ""}} ->
-            {:ok, ""}
+          {:ok, %{body: "", headers: headers}} ->
+            {:ok, "", headers}
 
           {:ok, response} ->
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data}
-              {:error, err} -> {:error, {:poison_decode_error, err}}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, response.headers}
             end
         end
     end
@@ -194,32 +166,6 @@ defmodule Binance.Futures.Coin.Rest.HTTPClient do
     end
   end
 
-  defp parse_response({:error, err}, :rate_limit) do
-    {:error, {:http_error, err}, parse_rate_limits(err)}
-  end
-
-  defp parse_response({:ok, %{status_code: status_code} = response}, :rate_limit)
-       when status_code not in 200..299 do
-    response.body
-    |> Poison.decode()
-    |> case do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}, parse_rate_limits(response)}
-
-      {:error, error} ->
-        {:error, {:poison_decode_error, error}, parse_rate_limits(response)}
-    end
-  end
-
-  defp parse_response({:ok, response}, :rate_limit) do
-    response.body
-    |> Poison.decode()
-    |> case do
-      {:ok, data} -> {:ok, data, parse_rate_limits(response)}
-      {:error, error} -> {:error, {:poison_decode_error, error}, parse_rate_limits(response)}
-    end
-  end
-
   defp parse_response({:error, err}) do
     {:error, {:http_error, err}}
   end
@@ -230,10 +176,10 @@ defmodule Binance.Futures.Coin.Rest.HTTPClient do
     |> Poison.decode()
     |> case do
       {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+        {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
       {:error, error} ->
-        {:error, {:poison_decode_error, error}}
+        {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 
@@ -241,8 +187,8 @@ defmodule Binance.Futures.Coin.Rest.HTTPClient do
     response.body
     |> Poison.decode()
     |> case do
-      {:ok, data} -> {:ok, data}
-      {:error, error} -> {:error, {:poison_decode_error, error}}
+      {:ok, data} -> {:ok, data, response.headers}
+      {:error, error} -> {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 end

--- a/lib/binance/futures/coin/websocket/ws_client.ex
+++ b/lib/binance/futures/coin/websocket/ws_client.ex
@@ -32,7 +32,7 @@ defmodule Binance.Futures.Coin.WebSocket.WSClient do
         state = Map.merge(args, %{heartbeat: 0, listen_key: nil, config: config})
 
         if require_auth == true do
-          {:ok, %{"listenKey" => listen_key}, _rate_limit} =
+          {:ok, %{"listenKey" => listen_key}, _headers} =
             Binance.CoinFutures.create_listen_key(%{}, config)
 
           state = Map.merge(state, %{listen_key: listen_key})

--- a/lib/binance/futures/rest/http_client.ex
+++ b/lib/binance/futures/rest/http_client.ex
@@ -1,7 +1,5 @@
 defmodule Binance.Futures.Rest.HTTPClient do
   @endpoint "https://fapi.binance.com"
-  @used_order_limit "X-MBX-ORDER-COUNT-1M"
-  @used_weight_limit "X-MBX-USED-WEIGHT-1M"
 
   alias Binance.{Config, Util}
 
@@ -12,7 +10,7 @@ defmodule Binance.Futures.Rest.HTTPClient do
 
   def delete_binance(url, headers \\ []) when is_list(headers) do
     HTTPoison.delete("#{@endpoint}#{url}", headers)
-    |> parse_response(:rate_limit)
+    |> parse_response
   end
 
   def get_binance(url, params, config) do
@@ -43,50 +41,24 @@ defmodule Binance.Futures.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.post("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            rate_limit = parse_rate_limits(err)
-            {:error, {:http_error, err}, rate_limit}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
-            rate_limit = parse_rate_limits(response)
-
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}, rate_limit}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}, rate_limit}
+                {:error, {:poison_decode_error, err}, response.headers}
             end
 
           {:ok, response} ->
-            rate_limit = parse_rate_limits(response)
-
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data, rate_limit}
-              {:error, err} -> {:error, {:poison_decode_error, err}, rate_limit}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, nil}
             end
         end
     end
-  end
-
-  defp parse_rate_limits(%HTTPoison.Response{headers: headers}) do
-    rates =
-      headers
-      |> Enum.reduce(
-        %{},
-        fn {k, v}, acc ->
-          case String.upcase(k) do
-            @used_order_limit -> Map.put(acc, :used_order_limit, v)
-            @used_weight_limit -> Map.put(acc, :used_weight_limit, v)
-            _ -> acc
-          end
-        end
-      )
-
-    if map_size(rates) != 0, do: rates, else: nil
-  end
-
-  defp parse_rate_limits(_) do
-    nil
   end
 
   def put_binance(url, params, config, signed? \\ true) do
@@ -97,24 +69,24 @@ defmodule Binance.Futures.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.put("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            {:error, {:http_error, err}}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}}
+                {:error, {:poison_decode_error, err}, nil}
             end
 
-          {:ok, %{body: ""}} ->
-            {:ok, ""}
+          {:ok, %{body: "", headers: headers}} ->
+            {:ok, "", headers}
 
           {:ok, response} ->
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data}
-              {:error, err} -> {:error, {:poison_decode_error, err}}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, response.headers}
             end
         end
     end
@@ -194,34 +166,8 @@ defmodule Binance.Futures.Rest.HTTPClient do
     end
   end
 
-  defp parse_response({:error, err}, :rate_limit) do
-    {:error, {:http_error, err}, parse_rate_limits(err)}
-  end
-
-  defp parse_response({:ok, %{status_code: status_code} = response}, :rate_limit)
-       when status_code not in 200..299 do
-    response.body
-    |> Poison.decode()
-    |> case do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}, parse_rate_limits(response)}
-
-      {:error, error} ->
-        {:error, {:poison_decode_error, error}, parse_rate_limits(response)}
-    end
-  end
-
-  defp parse_response({:ok, response}, :rate_limit) do
-    response.body
-    |> Poison.decode()
-    |> case do
-      {:ok, data} -> {:ok, data, parse_rate_limits(response)}
-      {:error, error} -> {:error, {:poison_decode_error, error}, parse_rate_limits(response)}
-    end
-  end
-
   defp parse_response({:error, err}) do
-    {:error, {:http_error, err}}
+    {:error, {:http_error, err}, nil}
   end
 
   defp parse_response({:ok, %{status_code: status_code} = response})
@@ -230,10 +176,10 @@ defmodule Binance.Futures.Rest.HTTPClient do
     |> Poison.decode()
     |> case do
       {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+        {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
       {:error, error} ->
-        {:error, {:poison_decode_error, error}}
+        {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 
@@ -241,8 +187,8 @@ defmodule Binance.Futures.Rest.HTTPClient do
     response.body
     |> Poison.decode()
     |> case do
-      {:ok, data} -> {:ok, data}
-      {:error, error} -> {:error, {:poison_decode_error, error}}
+      {:ok, data} -> {:ok, data, response.headers}
+      {:error, error} -> {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 end

--- a/lib/binance/futures/websocket/ws_client.ex
+++ b/lib/binance/futures/websocket/ws_client.ex
@@ -51,7 +51,7 @@ defmodule Binance.Futures.WebSocket.WSClient do
         state = Map.merge(args, %{heartbeat: 0, listen_key: nil, config: config})
 
         if require_auth == true do
-          {:ok, %{"listenKey" => listen_key}, _rate_limit} =
+          {:ok, %{"listenKey" => listen_key}, _headers} =
             Binance.Futures.create_listen_key(%{}, config)
 
           state = Map.merge(state, %{listen_key: listen_key})

--- a/lib/binance/margin.ex
+++ b/lib/binance/margin.ex
@@ -9,8 +9,8 @@ defmodule Binance.Margin do
 
   def create_listen_key(config \\ nil) do
     case HTTPClient.post_binance("/sapi/v1/userDataStream", %{}, config, false) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -24,8 +24,8 @@ defmodule Binance.Margin do
            config,
            false
          ) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -38,8 +38,8 @@ defmodule Binance.Margin do
     }
 
     case HTTPClient.put_binance("/sapi/v1/userDataStream", arguments, config, false) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -53,8 +53,8 @@ defmodule Binance.Margin do
     }
 
     case HTTPClient.put_binance("/sapi/v1/userDataStream/isolated", arguments, config, false) do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+      {:ok, %{"code" => code, "msg" => msg}, headers} ->
+        {:error, {:binance_error, %{code: code, msg: msg}}, headers}
 
       data ->
         data
@@ -63,8 +63,8 @@ defmodule Binance.Margin do
 
   def get_account(config \\ nil) do
     case HTTPClient.get_binance("/sapi/v1/margin/account", %{}, config) do
-      {:ok, data} ->
-        {:ok, Binance.Margin.Account.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.Margin.Account.new(data), headers}
 
       error ->
         error
@@ -73,8 +73,8 @@ defmodule Binance.Margin do
 
   def get_isolated_account(params \\ %{}, config \\ nil) do
     case HTTPClient.get_binance("/sapi/v1/margin/isolated/account", params, config) do
-      {:ok, data} ->
-        {:ok, Binance.Margin.IsolatedAccount.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.Margin.IsolatedAccount.new(data), headers}
 
       error ->
         error
@@ -83,32 +83,32 @@ defmodule Binance.Margin do
 
   def get_index_price(instrument, config \\ nil) do
     case HTTPClient.get_binance("/sapi/v1/margin/priceIndex", %{symbol: instrument}, config) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_best_ticker(String.t()) :: {:ok, map()} | {:error, error()}
+  @spec get_best_ticker(String.t()) :: {:ok, map(), any()} | {:error, error()}
   def get_best_ticker(instrument) do
     case HTTPClient.get_binance("/api/v3/ticker/bookTicker?symbol=#{instrument}") do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
-  @spec get_kline_data(String.t(), String.t(), number) :: {:ok, map()} | {:error, error()}
+  @spec get_kline_data(String.t(), String.t(), number) :: {:ok, map(), any()} | {:error, error()}
   def get_kline_data(instrument, interval, limit) do
     case HTTPClient.get_binance(
            "/api/v3/klines?symbol=#{instrument}&interval=#{interval}&limit=#{limit}"
          ) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
 
   def get_account_status(config \\ nil) do
     case HTTPClient.get_binance("/sapi/v1/account/status", %{}, config) do
-      {:ok, data} -> {:ok, data}
+      {:ok, data, headers} -> {:ok, data, headers}
       err -> err
     end
   end
@@ -160,8 +160,8 @@ defmodule Binance.Margin do
       )
 
     case HTTPClient.post_binance("/sapi/v1/margin/order", arguments, config) do
-      {:ok, data} ->
-        {:ok, Binance.Margin.Order.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.Margin.Order.new(data), headers}
 
       error ->
         error
@@ -169,10 +169,10 @@ defmodule Binance.Margin do
   end
 
   @spec get_open_orders(map(), map() | nil) ::
-          {:ok, list() | {:error, error()}}
+          {:ok, list(), any()} | {:error, error()}
   def get_open_orders(params \\ %{}, config \\ nil) do
     case HTTPClient.get_binance("/sapi/v1/margin/openOrders", params, config) do
-      {:ok, data} -> {:ok, Enum.map(data, &Binance.Margin.Order.new(&1))}
+      {:ok, data, headers} -> {:ok, Enum.map(data, &Binance.Margin.Order.new(&1)), headers}
       err -> err
     end
   end
@@ -201,8 +201,8 @@ defmodule Binance.Margin do
       )
 
     case HTTPClient.delete_binance("/sapi/v1/margin/order", arguments, config) do
-      {:ok, %{"rejectReason" => _} = err} -> {:error, err}
-      {:ok, data} -> {:ok, Binance.Margin.Order.new(data)}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, Binance.Margin.Order.new(data), headers}
       err -> err
     end
   end
@@ -219,8 +219,8 @@ defmodule Binance.Margin do
       )
 
     case HTTPClient.delete_binance("/sapi/v1/margin/openOrders", params, config) do
-      {:ok, %{"rejectReason" => _} = err} -> {:error, err}
-      {:ok, data} -> {:ok, Binance.Margin.Order.new(data)}
+      {:ok, %{"rejectReason" => _} = err, headers} -> {:error, err, headers}
+      {:ok, data, headers} -> {:ok, Binance.Margin.Order.new(data), headers}
       err -> err
     end
   end
@@ -257,11 +257,11 @@ defmodule Binance.Margin do
   Get the cross collateral wallet of a specific account
   """
   @spec get_cross_collateral_wallet(map() | nil) ::
-          {:ok, Binance.Margin.CrossCollateralWallet | {:error, error()}}
+          {:ok, Binance.Margin.CrossCollateralWallet, any()} | {:error, error()}
   def get_cross_collateral_wallet(config \\ nil) do
     case HTTPClient.get_binance("/sapi/v2/futures/loan/wallet", %{}, config) do
-      {:ok, data} ->
-        {:ok, Binance.Margin.CrossCollateralWallet.new(data)}
+      {:ok, data, headers} ->
+        {:ok, Binance.Margin.CrossCollateralWallet.new(data), headers}
 
       error ->
         error
@@ -292,11 +292,11 @@ defmodule Binance.Margin do
   ]}
   """
   @spec get_cross_collateral_info(map(), map() | nil) ::
-          {:ok, list(Binance.Margin.CrossCollateralInfo) | {:error, error()}}
+          {:ok, list(Binance.Margin.CrossCollateralInfo), any()} | {:error, error()}
   def get_cross_collateral_info(params \\ %{}, config \\ nil) do
     case HTTPClient.get_binance("/sapi/v2/futures/loan/configs", params, config) do
-      {:ok, data} ->
-        {:ok, Enum.map(data, &Binance.Margin.CrossCollateralInfo.new(&1))}
+      {:ok, data, headers} ->
+        {:ok, Enum.map(data, &Binance.Margin.CrossCollateralInfo.new(&1)), headers}
 
       error ->
         error

--- a/lib/binance/margin/rest/http_client.ex
+++ b/lib/binance/margin/rest/http_client.ex
@@ -1,9 +1,6 @@
 defmodule Binance.Margin.Rest.HTTPClient do
   @endpoint "https://api.binance.com"
 
-  @used_order_limit "X-SAPI-USED-UID-WEIGHT-1M"
-  @used_weight_limit "X-SAPI-USED-IP-WEIGHT-1M"
-
   alias Binance.{Config, Util}
 
   def get_binance(url, headers \\ []) when is_list(headers) do
@@ -13,7 +10,7 @@ defmodule Binance.Margin.Rest.HTTPClient do
 
   def delete_binance(url, headers \\ []) when is_list(headers) do
     HTTPoison.delete("#{@endpoint}#{url}", headers)
-    |> parse_response(:rate_limit)
+    |> parse_response
   end
 
   def get_binance(url, params, config) do
@@ -44,50 +41,24 @@ defmodule Binance.Margin.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.post("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            rate_limit = parse_rate_limits(err)
-            {:error, {:http_error, err}, rate_limit}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
-            rate_limit = parse_rate_limits(response)
-
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}, rate_limit}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}}
+                {:error, {:poison_decode_error, err}, response.headers}
             end
 
           {:ok, response} ->
-            rate_limit = parse_rate_limits(response)
-
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data, rate_limit}
-              {:error, err} -> {:error, {:poison_decode_error, err}, rate_limit}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, response.headers}
             end
         end
     end
-  end
-
-  defp parse_rate_limits(%HTTPoison.Response{headers: headers}) do
-    rates =
-      headers
-      |> Enum.reduce(
-        %{},
-        fn {k, v}, acc ->
-          case String.upcase(k) do
-            @used_order_limit -> Map.put(acc, :used_order_limit, v)
-            @used_weight_limit -> Map.put(acc, :used_weight_limit, v)
-            _ -> acc
-          end
-        end
-      )
-
-    if map_size(rates) != 0, do: rates, else: nil
-  end
-
-  defp parse_rate_limits(_) do
-    nil
   end
 
   def put_binance(url, params, config, signed? \\ true) do
@@ -98,24 +69,24 @@ defmodule Binance.Margin.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.put("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            {:error, {:http_error, err}}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}}
+                {:error, {:poison_decode_error, err}, response.headers}
             end
 
-          {:ok, %{body: ""}} ->
-            {:ok, ""}
+          {:ok, %{body: "", headers: headers}} ->
+            {:ok, "", headers}
 
           {:ok, response} ->
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data}
-              {:error, err} -> {:error, {:poison_decode_error, err}}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, response.headers}
             end
         end
     end
@@ -177,34 +148,8 @@ defmodule Binance.Margin.Rest.HTTPClient do
     end
   end
 
-  defp parse_response({:error, err}, :rate_limit) do
-    {:error, {:http_error, err}, parse_rate_limits(err)}
-  end
-
-  defp parse_response({:ok, %{status_code: status_code} = response}, :rate_limit)
-       when status_code not in 200..299 do
-    response.body
-    |> Poison.decode()
-    |> case do
-      {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}, parse_rate_limits(response)}
-
-      {:error, error} ->
-        {:error, {:poison_decode_error, error}, parse_rate_limits(response)}
-    end
-  end
-
-  defp parse_response({:ok, response}, :rate_limit) do
-    response.body
-    |> Poison.decode()
-    |> case do
-      {:ok, data} -> {:ok, data, parse_rate_limits(response)}
-      {:error, error} -> {:error, {:poison_decode_error, error}, parse_rate_limits(response)}
-    end
-  end
-
   defp parse_response({:error, err}) do
-    {:error, {:http_error, err}}
+    {:error, {:http_error, err}, nil}
   end
 
   defp parse_response({:ok, %{status_code: status_code} = response})
@@ -213,10 +158,10 @@ defmodule Binance.Margin.Rest.HTTPClient do
     |> Poison.decode()
     |> case do
       {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+        {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
       {:error, error} ->
-        {:error, {:poison_decode_error, error}}
+        {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 
@@ -224,8 +169,8 @@ defmodule Binance.Margin.Rest.HTTPClient do
     response.body
     |> Poison.decode()
     |> case do
-      {:ok, data} -> {:ok, data}
-      {:error, error} -> {:error, {:poison_decode_error, error}}
+      {:ok, data} -> {:ok, data, response.headers}
+      {:error, error} -> {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 end

--- a/lib/binance/rest/http_client.ex
+++ b/lib/binance/rest/http_client.ex
@@ -41,21 +41,21 @@ defmodule Binance.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.post("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            {:error, {:http_error, err}}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}}
+                {:error, {:poison_decode_error, err}, response.headers}
             end
 
           {:ok, response} ->
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data}
-              {:error, err} -> {:error, {:poison_decode_error, err}}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, response.headers}
             end
         end
     end
@@ -69,24 +69,24 @@ defmodule Binance.Rest.HTTPClient do
       {:ok, url, headers, body} ->
         case HTTPoison.put("#{@endpoint}#{url}", body, headers) do
           {:error, err} ->
-            {:error, {:http_error, err}}
+            {:error, {:http_error, err}, nil}
 
           {:ok, %{status_code: status_code} = response} when status_code not in 200..299 ->
             case Poison.decode(response.body) do
               {:ok, %{"code" => code, "msg" => msg}} ->
-                {:error, {:binance_error, %{code: code, msg: msg}}}
+                {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
               {:error, err} ->
-                {:error, {:poison_decode_error, err}}
+                {:error, {:poison_decode_error, err}, response.headers}
             end
 
-          {:ok, %{body: ""}} ->
-            {:ok, ""}
+          {:ok, %{body: "", headers: headers}} ->
+            {:ok, "", headers}
 
           {:ok, response} ->
             case Poison.decode(response.body) do
-              {:ok, data} -> {:ok, data}
-              {:error, err} -> {:error, {:poison_decode_error, err}}
+              {:ok, data} -> {:ok, data, response.headers}
+              {:error, err} -> {:error, {:poison_decode_error, err}, response.headers}
             end
         end
     end
@@ -149,7 +149,7 @@ defmodule Binance.Rest.HTTPClient do
   end
 
   defp parse_response({:error, err}) do
-    {:error, {:http_error, err}}
+    {:error, {:http_error, err}, nil}
   end
 
   defp parse_response({:ok, %{status_code: status_code} = response})
@@ -158,10 +158,10 @@ defmodule Binance.Rest.HTTPClient do
     |> Poison.decode()
     |> case do
       {:ok, %{"code" => code, "msg" => msg}} ->
-        {:error, {:binance_error, %{code: code, msg: msg}}}
+        {:error, {:binance_error, %{code: code, msg: msg}}, response.headers}
 
       {:error, error} ->
-        {:error, {:poison_decode_error, error}}
+        {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 
@@ -169,8 +169,8 @@ defmodule Binance.Rest.HTTPClient do
     response.body
     |> Poison.decode()
     |> case do
-      {:ok, data} -> {:ok, data}
-      {:error, error} -> {:error, {:poison_decode_error, error}}
+      {:ok, data} -> {:ok, data, response.headers}
+      {:error, error} -> {:error, {:poison_decode_error, error}, response.headers}
     end
   end
 end


### PR DESCRIPTION
Allow access to headers for all api responses. This allow us to access to `X-MBX-USED-WEIGHT-(intervalNum)(intervalLetter)` and `X-MBX-ORDER-COUNT-(intervalNum)(intervalLetter)` which are required to implement rate limit feature(s).